### PR TITLE
Unify asm versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,17 @@
             <groupId>org.pegdown</groupId>
             <artifactId>pegdown</artifactId>
             <version>1.6.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.parboiled</groupId>
+                    <artifactId>parboiled-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.parboiled</groupId>
+            <artifactId>parboiled-java</artifactId>
+            <version>1.3.1</version>
         </dependency>
         <!-- WebSocket-Server needed for running client-performance tests with Chrome and FF -->
         <dependency>
@@ -489,12 +500,6 @@
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
             <version>8.31</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-commons</artifactId>
-            <version>5.2</version>
             <scope>test</scope>
         </dependency>
         <!-- Cobertura -->


### PR DESCRIPTION
As of issue #22, there are several `asm*` artifacts that don't have the same version. This might lead to compatibility issues as there are dependencies between those artifacts.