### PR TITLE
#105: Write total ramp-up period to the results

### DIFF
--- a/src/main/java/com/xceptance/xlt/common/XltConstants.java
+++ b/src/main/java/com/xceptance/xlt/common/XltConstants.java
@@ -138,28 +138,22 @@ public final class XltConstants
      * The name of the timer files.
      */
     public static final String TIMER_FILENAME = "timers.csv";
-    
+
     /**
      * The possible name of the timer files.
      */
-    public static final List<Pattern> TIMER_FILENAME_PATTERNS = 
-        Stream.of(
-                  "^timers\\.csv$", 
-                  "^timers\\.csv\\.gz$", 
-                  "^timers\\.csv\\.[0-9]{4}-[0-9]{2}-[0-9]{2}$", 
-                  "^timers\\.csv\\.[0-9]{4}-[0-9]{2}-[0-9]{2}\\.gz$")
-        .map(Pattern::compile).collect(Collectors.toList());
+    public static final List<Pattern> TIMER_FILENAME_PATTERNS = Stream.of("^timers\\.csv$", "^timers\\.csv\\.gz$",
+                                                                          "^timers\\.csv\\.[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                                                                          "^timers\\.csv\\.[0-9]{4}-[0-9]{2}-[0-9]{2}\\.gz$")
+                                                                      .map(Pattern::compile).collect(Collectors.toList());
 
     /**
      * The possible name of the CPT timer files.
      * <p>
      * Note: Needed for backward compatibility. Separate CPT timers files have been removed in XLT 4.8.
      */
-    public static final List<Pattern> CPT_TIMER_FILENAME_PATTERNS = 
-        Stream.of(
-                  "^timer-wd-.+\\.csv$", 
-                  "^timer-wd-.+\\.csv\\.gz$")
-        .map(Pattern::compile).collect(Collectors.toList());
+    public static final List<Pattern> CPT_TIMER_FILENAME_PATTERNS = Stream.of("^timer-wd-.+\\.csv$", "^timer-wd-.+\\.csv\\.gz$")
+                                                                          .map(Pattern::compile).collect(Collectors.toList());
 
     /**
      * The option name of the <em>from</em> option on the command line.
@@ -421,7 +415,9 @@ public final class XltConstants
      */
     public static final String LOAD_TEST_ELAPSED_TIME = XLT_PACKAGE_PATH + ".loadtest.elapsed";
 
-    /*
-     * Client performance
+    /**
+     * The name of the property that denotes how many milliseconds it took for all active test scenarios to finish their
+     * ramp-up.
      */
+    public static final String LOAD_TEST_RAMP_UP_PERIOD = XLT_PACKAGE_PATH + ".loadtest.rampUp";
 }

--- a/src/main/java/com/xceptance/xlt/mastercontroller/TestLoadProfileConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/TestLoadProfileConfiguration.java
@@ -280,6 +280,32 @@ public class TestLoadProfileConfiguration extends AbstractConfiguration
     }
 
     /**
+     * Returns the total time (in seconds) it takes for all active test scenarios to finish their ramp-up. This value is
+     * relative to the moment when the first scenario would begin to run. Initial delays are taken into consideration.
+     * 
+     * @return the total ramp-up time [s]
+     */
+    public long getTotalRampUpPeriod()
+    {
+        long maxRampUpOffset = 0L;
+        long smallestInitialDelay = Long.MAX_VALUE;
+
+        for (final TestCaseLoadProfileConfiguration loadProfile : getLoadTestConfiguration())
+        {
+            // initial delay + ramp-up is offset
+            final int initialDelay = loadProfile.getInitialDelay();
+            final int rampUpPeriod = loadProfile.getRampUpPeriod();
+            if (rampUpPeriod > 0)
+            {
+                maxRampUpOffset = Math.max(maxRampUpOffset, initialDelay + rampUpPeriod);
+            }
+            smallestInitialDelay = Math.min(smallestInitialDelay, initialDelay);
+        }
+
+        return Math.max(0, maxRampUpOffset - smallestInitialDelay);
+    }
+
+    /**
      * Reads, parses and returns the load test configurations from the configured location.
      *
      * @return test configurations

--- a/src/main/java/com/xceptance/xlt/report/ReportGenerator.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGenerator.java
@@ -356,7 +356,7 @@ public class ReportGenerator
             // get load profile
             final File configDir = new File(inputDir.getName().getPath(), XltConstants.CONFIG_DIR_NAME);
             final TestLoadProfileConfiguration loadProfileConfig = new TestLoadProfileConfiguration(configDir.getParentFile(), configDir);
-            final long endOfRampUpTime = startTime + computeRampUpOffset(loadProfileConfig.getLoadTestConfiguration()) * 1000L;
+            final long endOfRampUpTime = startTime + loadProfileConfig.getTotalRampUpPeriod() * 1000L;
             // determine what time is more recent: end of ramp-up or given 'from'
             fromTime = Math.max(fromTime, endOfRampUpTime);
         }
@@ -698,25 +698,5 @@ public class ReportGenerator
         }
 
         return inputDirName;
-    }
-
-    static long computeRampUpOffset(final List<TestCaseLoadProfileConfiguration> profiles)
-    {
-        // determine highest offset from the start time when all tests have completed their ramp-up
-        long maxRampUpOffset = 0L;
-        long smallestInitialDelay = Long.MAX_VALUE;
-        for (final TestCaseLoadProfileConfiguration profile : profiles)
-        {
-            // initial delay + ramp-up is offset
-            final int initialDelay = profile.getInitialDelay();
-            final int rampUpPeriod = profile.getRampUpPeriod();
-            if (rampUpPeriod > 0)
-            {
-                maxRampUpOffset = Math.max(maxRampUpOffset, initialDelay + rampUpPeriod);
-            }
-            smallestInitialDelay = Math.min(smallestInitialDelay, initialDelay);
-        }
-
-        return Math.max(0, maxRampUpOffset - smallestInitialDelay);
     }
 }

--- a/src/test/java/com/xceptance/xlt/mastercontroller/TestLoadProfileConfiguration_RampUpOffsetTest.java
+++ b/src/test/java/com/xceptance/xlt/mastercontroller/TestLoadProfileConfiguration_RampUpOffsetTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.xceptance.xlt.report;
+package com.xceptance.xlt.mastercontroller;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,20 +24,18 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.xceptance.xlt.mastercontroller.TestCaseLoadProfileConfiguration;
-
 @RunWith(Parameterized.class)
-public class ReportGenerator_RampUpOffsetTest
+public class TestLoadProfileConfiguration_RampUpOffsetTest
 {
     @Parameters
     public static Object[][] Data()
     {
-        final TestCaseLoadProfileConfiguration iD_1h = makeProfile(3600, 0);
-        final TestCaseLoadProfileConfiguration rU_15m = makeProfile(0, 900);
-        final TestCaseLoadProfileConfiguration rU_20m = makeProfile(0, 1200);
+        final TestCaseLoadProfileConfiguration iD_1h = makeProfile("T1", 3600, 0);
+        final TestCaseLoadProfileConfiguration rU_15m = makeProfile("T2", 0, 900);
+        final TestCaseLoadProfileConfiguration rU_20m = makeProfile("T3", 0, 1200);
 
-        final TestCaseLoadProfileConfiguration iD_2h_rU_1h = makeProfile(7200, 3600);
-        final TestCaseLoadProfileConfiguration iD_5m_rU_15m = makeProfile(300, 900);
+        final TestCaseLoadProfileConfiguration iD_2h_rU_1h = makeProfile("T4", 7200, 3600);
+        final TestCaseLoadProfileConfiguration iD_5m_rU_15m = makeProfile("T5", 300, 900);
 
         return new Object[][]
             {
@@ -81,7 +79,7 @@ public class ReportGenerator_RampUpOffsetTest
 
     private final long _rampUpOffset;
 
-    public ReportGenerator_RampUpOffsetTest(final List<TestCaseLoadProfileConfiguration> profiles, final long rampUpOffset)
+    public TestLoadProfileConfiguration_RampUpOffsetTest(final List<TestCaseLoadProfileConfiguration> profiles, final long rampUpOffset)
     {
         _profiles = profiles;
         _rampUpOffset = rampUpOffset;
@@ -90,14 +88,18 @@ public class ReportGenerator_RampUpOffsetTest
     @Test
     public void computeRampUpOffset() throws Exception
     {
-        final long computedOffset = ReportGenerator.computeRampUpOffset(_profiles);
+        TestLoadProfileConfiguration config = new TestLoadProfileConfiguration();
+        _profiles.forEach(profile -> config.addTestCaseLoadProfileConfiguration(profile));
+
+        final long computedOffset = config.getTotalRampUpPeriod();
 
         Assert.assertEquals("Unexpected ramp-up offset for " + _profiles, _rampUpOffset, computedOffset);
     }
 
-    private static TestCaseLoadProfileConfiguration makeProfile(final int initialDelay, final int rampUpPeriod)
+    private static TestCaseLoadProfileConfiguration makeProfile(final String userName, final int initialDelay, final int rampUpPeriod)
     {
         final TestCaseLoadProfileConfiguration profile = new TestCaseLoadProfileConfiguration();
+        profile.setUserName(userName);
         profile.setInitialDelay(initialDelay);
         profile.setRampUpPeriod(rampUpPeriod);
 


### PR DESCRIPTION
* moved method to compute the total ramp-up period from ReportGenerator to LoadTestProfileConfiguration
* moved test case ReportGenerator_RampUpOffsetTest to LoadTestProfileConfiguration_RampUpOffsetTest and adjusted it accordingly
* have the ResultsDownloader write the total ramp-up time to the test properties file
* simplified ResultsDownloader a bit