### PR TITLE
#119: Add transaction errors to "Agents" report page

### DIFF
--- a/config/testreport/js/xlt.js
+++ b/config/testreport/js/xlt.js
@@ -307,7 +307,7 @@
             function determineTotalsFunctionBy(aColumnDescription, aMean) {
                 var regexForColumnsWithMinTotal = /Min\.$/;
                 var regexForColumnsWithMaxTotal = /Max\.$/;
-                var regexForColumnsWithSumTotal = /(Total|1\/(s|min|h|d)\*?)$/;
+                var regexForColumnsWithSumTotal = /(Total|Errors|1\/(s|min|h|d)\*?)$/;
                 var regexForColumnsWithAverageTotal = /\sGC\s|CPU\s\[%\]/; // matches columns in Agents table
 
                 function minimum(total, current) {

--- a/config/xsl/loadreport/sections/agents.xsl
+++ b/config/xsl/loadreport/sections/agents.xsl
@@ -19,28 +19,38 @@
                                     <br/>
                                     <input class="filter" placeholder="Enter filter substrings"/>
                                 </th>
-                                <th colspan="2">Total CPU [%]</th>
-                                <th colspan="2" class="colgroup1">Agent CPU [%]</th>
-                                <th colspan="3">Minor GC</th>
-                                <th colspan="3" class="colgroup1">Full GC</th>
+                                <th colspan="3">Transactions</th>
+                                <th colspan="2" class="colgroup1">Total CPU [%]</th>
+                                <th colspan="2">Agent CPU [%]</th>
+                                <th colspan="3" class="colgroup1">Minor GC</th>
+                                <th colspan="3">Full GC</th>
                             </tr>
                             <tr>
-                                <th class="table-sortable:numeric">Mean</th>
-                                <th class="table-sortable:numeric">Max.</th>
+                                <th class="table-sortable:numeric">Total</th>
+                                <th class="table-sortable:numeric">Errors</th>
+                                <th class="table-sortable:numeric">%</th>
                                 <th class="table-sortable:numeric colgroup1">Mean</th>
                                 <th class="table-sortable:numeric colgroup1">Max.</th>
-                                <th class="table-sortable:numeric">Count</th>
-                                <th class="table-sortable:numeric">Time [ms]</th>
-                                <th class="table-sortable:numeric">CPU [%]</th>
+                                <th class="table-sortable:numeric">Mean</th>
+                                <th class="table-sortable:numeric">Max.</th>
                                 <th class="table-sortable:numeric colgroup1">Count</th>
                                 <th class="table-sortable:numeric colgroup1">Time [ms]</th>
                                 <th class="table-sortable:numeric colgroup1">CPU [%]</th>
+                                <th class="table-sortable:numeric">Count</th>
+                                <th class="table-sortable:numeric">Time [ms]</th>
+                                <th class="table-sortable:numeric">CPU [%]</th>
                             </tr>
                         </thead>
                         <xsl:variable name="count" select="count($rootNode/agent)"/>
                         <xsl:choose>
                             <xsl:when test="$count > 0">
                                 <tfoot>
+                                    <xsl:variable name="totalTransactions">
+                                        <xsl:value-of select="sum($rootNode/agent/transactions)" />
+                                    </xsl:variable>
+                                    <xsl:variable name="totalTransactionErrors">
+                                        <xsl:value-of select="sum($rootNode/agent/transactionErrors)" />
+                                    </xsl:variable>
                                     <tr class="totals">
                                         <xsl:call-template name="create-totals-td">
                                             <xsl:with-param name="rows-in-table" select="$count"/>
@@ -48,10 +58,32 @@
                                         </xsl:call-template>
 
                                         <td class="value number">
+                                            <xsl:value-of select="format-number($totalTransactions, '#,##0')"/>
+                                        </td>
+                                        <td class="value number">
+                                            <xsl:if test="$totalTransactionErrors &gt; 0">
+                                                <xsl:attribute name="class">value number error</xsl:attribute>
+                                            </xsl:if>
+                                            <xsl:value-of select="format-number($totalTransactionErrors, '#,##0')"/>
+                                        </td>
+                                        <td class="value number">
+                                            <xsl:if test="$totalTransactionErrors &gt; 0">
+                                                <xsl:attribute name="class">value number error</xsl:attribute>
+                                            </xsl:if>
+                                            <xsl:variable name="totalTransactionErrorPercentage">
+                                                <xsl:call-template name="percentage">
+                                                    <xsl:with-param name="n1" select="$totalTransactions" />
+                                                    <xsl:with-param name="n2" select="$totalTransactionErrors" />
+                                                </xsl:call-template>
+                                            </xsl:variable>
+                                            <xsl:value-of select="format-number($totalTransactionErrorPercentage, '#,##0.00')" />
+                                            <xsl:text>%</xsl:text>
+                                        </td>
+                                        <td class="value number colgroup1">
                                             <xsl:value-of
                                                 select="format-number(sum($rootNode/agent/totalCpuUsage/mean) div $count, '#,##0.00')"/>
                                         </td>
-                                        <td class="value number">
+                                        <td class="value number colgroup1">
                                             <xsl:variable name="maxTotalCpu">
                                                 <xsl:call-template name="max">
                                                     <xsl:with-param name="seq" select="$rootNode/agent/totalCpuUsage/max"/>
@@ -59,11 +91,11 @@
                                             </xsl:variable>
                                             <xsl:value-of select="format-number($maxTotalCpu, '#,##0.00')"/>
                                         </td>
-                                        <td class="value number colgroup1">
+                                        <td class="value number">
                                             <xsl:value-of
                                                 select="format-number(sum($rootNode/agent/cpuUsage/mean) div $count, '#,##0.00')"/>
                                         </td>
-                                        <td class="value number colgroup1">
+                                        <td class="value number">
                                             <xsl:variable name="maxCpu">
                                                 <xsl:call-template name="max">
                                                     <xsl:with-param name="seq" select="$rootNode/agent/cpuUsage/max"/>
@@ -71,23 +103,23 @@
                                             </xsl:variable>
                                             <xsl:value-of select="format-number($maxCpu, '#,##0.00')"/>
                                         </td>
-                                        <td class="value number">
+                                        <td class="value number colgroup1">
                                             <xsl:value-of select="format-number(sum($rootNode/agent/minorGcCount) div $count, '#,##0')"/>
                                         </td>
-                                        <td class="value number">
+                                        <td class="value number colgroup1">
                                             <xsl:value-of select="format-number(sum($rootNode/agent/minorGcTime) div $count, '#,##0')"/>
                                         </td>
-                                        <td class="value number">
+                                        <td class="value number colgroup1">
                                             <xsl:value-of
                                                 select="format-number(sum($rootNode/agent/minorGcCpuUsage) div $count, '#,##0.00')"/>
                                         </td>
-                                        <td class="value number colgroup1">
+                                        <td class="value number">
                                             <xsl:value-of select="format-number(sum($rootNode/agent/fullGcCount) div $count, '#,##0')"/>
                                         </td>
-                                        <td class="value number colgroup1">
+                                        <td class="value number">
                                             <xsl:value-of select="format-number(sum($rootNode/agent/fullGcTime) div $count, '#,##0')"/>
                                         </td>
-                                        <td class="value number colgroup1">
+                                        <td class="value number">
                                             <xsl:value-of
                                                 select="format-number(sum($rootNode/agent/fullGcCpuUsage) div $count, '#,##0.00')"/>
                                         </td>
@@ -111,33 +143,55 @@
                                                 </a>
                                             </td>
                                             <td class="value number">
+                                                <xsl:value-of select="format-number(transactions, '#,##0')"/>
+                                            </td>
+                                            <td class="value number">
+                                                <xsl:if test="transactionErrors &gt; 0">
+                                                    <xsl:attribute name="class">value number error</xsl:attribute>
+                                                </xsl:if>
+                                                <xsl:value-of select="format-number(transactionErrors, '#,##0')"/>
+                                            </td>
+                                            <td class="value number">
+                                                <xsl:if test="transactionErrors &gt; 0">
+                                                    <xsl:attribute name="class">value number error</xsl:attribute>
+                                                </xsl:if>
+                                                <xsl:variable name="transactionErrorPercentage">
+                                                    <xsl:call-template name="percentage">
+                                                        <xsl:with-param name="n1" select="transactions" />
+                                                        <xsl:with-param name="n2" select="transactionErrors" />
+                                                    </xsl:call-template>
+                                                </xsl:variable>
+                                                <xsl:value-of select="format-number($transactionErrorPercentage, '#,##0.00')" />
+                                                <xsl:text>%</xsl:text>
+                                            </td>
+                                            <td class="value number colgroup1">
                                                 <xsl:value-of select="format-number(totalCpuUsage/mean, '#,##0.00')"/>
                                             </td>
-                                            <td class="value number">
+                                            <td class="value number colgroup1">
                                                 <xsl:value-of select="format-number(totalCpuUsage/max, '#,##0.00')"/>
                                             </td>
-                                            <td class="value number colgroup1">
+                                            <td class="value number">
                                                 <xsl:value-of select="format-number(cpuUsage/mean, '#,##0.00')"/>
                                             </td>
-                                            <td class="value number colgroup1">
+                                            <td class="value number">
                                                 <xsl:value-of select="format-number(cpuUsage/max, '#,##0.00')"/>
                                             </td>
-                                            <td class="value number">
+                                            <td class="value number colgroup1">
                                                 <xsl:value-of select="format-number(minorGcCount, '#,##0')"/>
                                             </td>
-                                            <td class="value number">
+                                            <td class="value number colgroup1">
                                                 <xsl:value-of select="format-number(minorGcTime, '#,##0')"/>
                                             </td>
-                                            <td class="value number">
+                                            <td class="value number colgroup1">
                                                 <xsl:value-of select="format-number(minorGcCpuUsage, '#,##0.00')"/>
                                             </td>
-                                            <td class="value number colgroup1">
+                                            <td class="value number">
                                                 <xsl:value-of select="format-number(fullGcCount, '#,##0')"/>
                                             </td>
-                                            <td class="value number colgroup1">
+                                            <td class="value number">
                                                 <xsl:value-of select="format-number(fullGcTime, '#,##0')"/>
                                             </td>
-                                            <td class="value number colgroup1">
+                                            <td class="value number">
                                                 <xsl:value-of select="format-number(fullGcCpuUsage, '#,##0.00')"/>
                                             </td>
                                         </tr>
@@ -148,15 +202,16 @@
                                 <tfoot>
                                     <tr>
                                         <td class="colgroup1"></td>
-                                        <td></td>
-                                        <td class="colgroup1"></td>
                                         <td colspan="3"></td>
+                                        <td colspan="2" class="colgroup1"></td>
+                                        <td colspan="2"></td>
                                         <td colspan="3" class="colgroup1"></td>
+                                        <td colspan="3"></td>
                                     </tr>
                                 </tfoot>
                                 <tbody>
                                     <tr>
-                                        <td class="value text" colspan="9">There are no values to show in this table.</td>
+                                        <td class="value text" colspan="14">There are no values to show in this table.</td>
                                     </tr>
                                 </tbody>
                             </xsl:otherwise>

--- a/config/xsl/loadreport/text/descriptions.xsl
+++ b/config/xsl/loadreport/text/descriptions.xsl
@@ -588,7 +588,7 @@
         <div class="description">
             <xsl:variable name="gid" select="concat('agents', generate-id(.))"/>
             <p>
-                The Agent Information section reports on the resource utilization of each user agent in terms of CPU and memory
+                The Agent Information section reports mainly on the resource utilization of each user agent in terms of CPU and memory
                 usage.
                 <xsl:call-template name="show-n-hide">
                     <xsl:with-param name="gid" select="$gid"/>

--- a/src/main/java/com/xceptance/xlt/report/providers/AbstractDataProcessor.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/AbstractDataProcessor.java
@@ -40,12 +40,10 @@ public abstract class AbstractDataProcessor
 
     private ChartCappingInfo chartCappingInfo;
 
-
-    
     /**
      * The name of the timer processed by this data processor.
      */
-    private final String name;
+    private String name;
 
     /**
      * The report provider to which this data processor belongs.
@@ -155,6 +153,17 @@ public abstract class AbstractDataProcessor
     public String getName()
     {
         return name;
+    }
+
+    /**
+     * Sets the timer name.
+     * 
+     * @param name
+     *            the new name
+     */
+    public void setName(final String name)
+    {
+        this.name = name;
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/report/providers/AgentDataProcessor.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/AgentDataProcessor.java
@@ -76,6 +76,10 @@ public class AgentDataProcessor extends AbstractDataProcessor
 
     private final DoubleMinMaxValueSet totalCpuUsageValueSet;
 
+    private int transactions;
+
+    private int transactionErrors;
+
     /**
      * Creates a new {@link AbstractDataProcessor} instance.
      * 
@@ -152,6 +156,9 @@ public class AgentDataProcessor extends AbstractDataProcessor
         agentReport.cpuUsage = createStatisticsReport(cpuUsageStats);
         agentReport.totalCpuUsage = createStatisticsReport(totalCpuUsageStats);
 
+        agentReport.transactions = transactions;
+        agentReport.transactionErrors = transactionErrors;
+
         return agentReport;
     }
 
@@ -216,6 +223,23 @@ public class AgentDataProcessor extends AbstractDataProcessor
         minorGcTime = Math.max(minorGcTime, usageStats.getMinorGcTime());
         fullGcCount = Math.max(fullGcCount, usageStats.getFullGcCount());
         fullGcTime = Math.max(fullGcTime, usageStats.getFullGcTime());
+    }
+
+    /**
+     * Increments the transaction counter (and maybe the transaction error counter) of the agent this data processor is
+     * responsible for.
+     * 
+     * @param failed
+     *            whether the transaction to be added has failed
+     */
+    void incrementTransactionCounters(final boolean failed)
+    {
+        transactions++;
+
+        if (failed)
+        {
+            transactionErrors++;
+        }
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/report/providers/AgentReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/AgentReport.java
@@ -41,4 +41,8 @@ public class AgentReport
     public long minorGcTime;
 
     public String name;
+
+    public int transactions;
+
+    public int transactionErrors;
 }

--- a/src/main/java/com/xceptance/xlt/report/providers/AgentsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/AgentsReportProvider.java
@@ -57,16 +57,24 @@ public class AgentsReportProvider extends AbstractDataProcessorBasedReportProvid
     public void processDataRecord(final Data data)
     {
         /*
-         * Agent data processors are keyed by agent ID (e.g. 'ac0001_us-east1') and not - as usual elsewhere - by name
-         * (e.g. 'Agent-ac0001_us-east1_00-34.138.16.104-8500'). This allows to look up an agent data processor also for
-         * TransactionData instances, which only carry the agent ID.
+         * An agent processor bundles all data gathered for a certain agent, now also certain transaction data. When
+         * looking up the responsible agent processor for a Data object, we can no longer use the full agent name (e.g.
+         * 'Agent-ac0001_us-east1_00-34.138.16.104-8500') as this information is available for JvmResourceUsageData
+         * objects only. Instead, we now use the agent ID (e.g. 'ac0001_us-east1'), as all types of Data objects carry
+         * this information. This approach is different from other report providers that are based on
+         * AbstractDataProcessorBasedReportProvider.
          */
 
         if (data instanceof JvmResourceUsageData)
         {
             final AgentDataProcessor processor = getProcessor(data.getAgentName());
             processor.processDataRecord(data);
-            // HACK: set the regular agent name
+
+            /*
+             * If we use the agent ID to reference the agent processor, the agent would be named as such in the report
+             * as well. Since we want the full agent name in the report, we have to "fix" the initial name by setting
+             * the full name later on.
+             */
             processor.setName(data.getName());
         }
         else if (data instanceof TransactionData)


### PR DESCRIPTION
- provide transaction count and error count as part of the agent data
- added new columns to the agent table displaying transaction count, error count, and error percentage per agent