### PR TITLE
#129: Option to configure download result amount in non-interactive mode

### DIFF
--- a/src/main/java/com/xceptance/xlt/agentcontroller/AgentManagerImpl.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/AgentManagerImpl.java
@@ -50,19 +50,33 @@ public class AgentManagerImpl implements AgentManager, AgentListener
     /**
      * A file filter that ignores result browser directories (directories named "output").
      */
-    private static final IOFileFilter NO_RESULTBROWSER_FILTER = FileFilterUtils.notFileFilter(FileFilterUtils.makeDirectoryOnly(new NameFileFilter(
-                                                                                                                                                   "output")));
+    private static final IOFileFilter NO_RESULTBROWSER_FILTER = FileFilterUtils.notFileFilter(FileFilterUtils.makeDirectoryOnly(new NameFileFilter("output")));
 
     /**
      * A file filter that ignores agent log files.
      */
-    private static final IOFileFilter NO_AGENTLOG_FILTER = FileFilterUtils.notFileFilter(FileFilterUtils.makeFileOnly(new WildcardFileFilter(
-                                                                                                                                             "agent*.log*")));
+    private static final IOFileFilter NO_AGENTLOG_FILTER = FileFilterUtils.notFileFilter(FileFilterUtils.makeFileOnly(new WildcardFileFilter("agent*.log*")));
+
+    /**
+     * A file filter that ignores timer files.
+     */
+    private static final IOFileFilter NO_TIMERS_FILTER = FileFilterUtils.notFileFilter(FileFilterUtils.makeFileOnly(new WildcardFileFilter("timers.csv*")));
 
     /**
      * A file filter that ignores both agent log files and result browser directories.
      */
-    private static final IOFileFilter NO_AGENTLOG_NO_RESULTBROWSER_FILTER = FileFilterUtils.and(NO_RESULTBROWSER_FILTER, NO_AGENTLOG_FILTER);
+    private static final IOFileFilter NO_AGENTLOG_NO_RESULTBROWSER_FILTER = FileFilterUtils.and(NO_RESULTBROWSER_FILTER,
+                                                                                                NO_AGENTLOG_FILTER);
+
+    /**
+     * A file filter that ignores both agent log files and timer files.
+     */
+    private static final IOFileFilter NO_AGENTLOG_NO_TIMERS_FILTER = FileFilterUtils.and(NO_AGENTLOG_FILTER, NO_TIMERS_FILTER);
+
+    /**
+     * A file filter that ignores both result browser directories and timer files.
+     */
+    private static final IOFileFilter NO_RESULTBROWSER_NO_TIMERS_FILTER = FileFilterUtils.and(NO_RESULTBROWSER_FILTER, NO_TIMERS_FILTER);
 
     /**
      * agent
@@ -185,6 +199,18 @@ public class AgentManagerImpl implements AgentManager, AgentListener
                     break;
                 case MEASUREMENTS_ONLY:
                     fileFilter = NO_AGENTLOG_NO_RESULTBROWSER_FILTER;
+                    break;
+                case MEASUREMENTS_AND_LOGS:
+                    fileFilter = NO_RESULTBROWSER_FILTER;
+                    break;
+                case RESULTBROWSER_AND_LOGS:
+                    fileFilter = NO_TIMERS_FILTER;
+                    break;
+                case RESULTBROWSER_ONLY:
+                    fileFilter = NO_AGENTLOG_NO_TIMERS_FILTER;
+                    break;
+                case LOGS_ONLY:
+                    fileFilter = NO_RESULTBROWSER_NO_TIMERS_FILTER;
                     break;
                 default:
                     fileFilter = null;
@@ -341,10 +367,8 @@ public class AgentManagerImpl implements AgentManager, AgentListener
         {
             // get file indexes
             final FileReplicationIndex srcIndex = FileReplicationUtils.getIndex(sourceDir, FileFilterUtils.makeSVNAware(null));
-            final FileReplicationIndex dstIndex = getAgentInfo().getAgentDirectory().exists()
-                                                                                             ? FileReplicationUtils.getIndex(getAgentInfo().getAgentDirectory(),
-                                                                                                                             FileFilterUtils.makeSVNAware(null))
-                                                                                             : new FileReplicationIndex();
+            final FileReplicationIndex dstIndex = getAgentInfo().getAgentDirectory()
+                                                                .exists() ? FileReplicationUtils.getIndex(getAgentInfo().getAgentDirectory(), FileFilterUtils.makeSVNAware(null)) : new FileReplicationIndex();
 
             // get the files to be updated or deleted on the target
             final List<File> filesToBeDeleted = new ArrayList<File>();

--- a/src/main/java/com/xceptance/xlt/agentcontroller/TestResultAmount.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/TestResultAmount.java
@@ -23,10 +23,10 @@ public enum TestResultAmount
     ALL("Measurements, result browser data, and logs [all]", "1"),
     MEASUREMENTS_AND_RESULTBROWSER("Measurements and result browser data", "2"),
     MEASUREMENTS_AND_LOGS("Measurements and logs", "3"),
-    MEASUREMENTS_ONLY("Measurements only", "3"),
-    RESULTBROWSER_AND_LOGS("Result browser data and logs", "4"),
-    RESULTBROWSER_ONLY("Result browser only", "5"),
-    LOGS_ONLY("Logs only", "6"),
+    MEASUREMENTS_ONLY("Measurements only", "4"),
+    RESULTBROWSER_AND_LOGS("Result browser data and logs", "5"),
+    RESULTBROWSER_ONLY("Result browser only", "6"),
+    LOGS_ONLY("Logs only", "7"),
     CANCEL("Cancel", "c");
 
     private static final String[] displayNames;

--- a/src/main/java/com/xceptance/xlt/agentcontroller/TestResultAmount.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/TestResultAmount.java
@@ -22,7 +22,11 @@ public enum TestResultAmount
 {
     ALL("Measurements, result browser data, and logs [all]", "1"),
     MEASUREMENTS_AND_RESULTBROWSER("Measurements and result browser data", "2"),
+    MEASUREMENTS_AND_LOGS("Measurements and logs", "3"),
     MEASUREMENTS_ONLY("Measurements only", "3"),
+    RESULTBROWSER_AND_LOGS("Result browser data and logs", "4"),
+    RESULTBROWSER_ONLY("Result browser only", "5"),
+    LOGS_ONLY("Logs only", "6"),
     CANCEL("Cancel", "c");
 
     private static final String[] displayNames;

--- a/src/main/java/com/xceptance/xlt/mastercontroller/FireAndForgetUI.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/FireAndForgetUI.java
@@ -105,6 +105,11 @@ public class FireAndForgetUI extends BasicConsoleUI
     private final long initialResponseTimeout;
 
     /**
+     * The amount of test results to be downloaded.
+     */
+    private final TestResultAmount testResultAmount;
+
+    /**
      * Creates a new FireAndForgetUI object.
      * 
      * @param masterController
@@ -115,9 +120,13 @@ public class FireAndForgetUI extends BasicConsoleUI
      *            whether a test report will be automatically created right after downloading the test results
      * @param noResults
      *            whether test results should not be downloaded (this also prevents report generation)
+     * @param initialResponseTimeout
+     *            the maximum time to wait for configured agent controllers to be up and running
+     * @param resultAmount
+     *            the amount of test results to download
      */
     public FireAndForgetUI(final MasterController masterController, final boolean isSequential, final boolean generateReport,
-                           final boolean noResults, final long initialResponseTimeout)
+                           final boolean noResults, final long initialResponseTimeout, final TestResultAmount resultAmount)
     {
         super(masterController);
 
@@ -125,6 +134,7 @@ public class FireAndForgetUI extends BasicConsoleUI
         this.generateReport = generateReport && !noResults;
         this.noResults = noResults;
         this.initialResponseTimeout = initialResponseTimeout;
+        this.testResultAmount = resultAmount;
     }
 
     /**
@@ -297,7 +307,7 @@ public class FireAndForgetUI extends BasicConsoleUI
             }
             else
             {
-                if (!downloadTestResults(TestResultAmount.ALL))
+                if (!downloadTestResults(testResultAmount))
                 {
                     throw new RuntimeException("Downloading test results failed.");
                 }

--- a/src/main/java/com/xceptance/xlt/mastercontroller/Main.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/Main.java
@@ -542,17 +542,30 @@ public class Main
             }
             else
             {
-                // validate option values
-                final String[] unknownTypes = ResultDataTypes.validate(commandLine.getOptionValue(OPTION_DOWNLOAD));
-                if (unknownTypes.length > 0)
+                // validate option value
+                final String downloadOptValue = StringUtils.stripToNull(commandLine.getOptionValue(OPTION_DOWNLOAD));
+                if (downloadOptValue == null)
                 {
-                    final String message = String.format("Unrecognized values passed as argument to '--%s' option: %s\nSupported values: %s",
-                                                         OPTION_DOWNLOAD, StringUtils.join(unknownTypes, ", "),
-                                                         StringUtils.join(ResultDataTypes.values(), ", "));
+                    final String message = String.format("Option '--%s' requires an argument but none was given (or consists of whitespace characters only).",
+                                                         OPTION_DOWNLOAD);
                     System.out.println(message);
                     log.error(message);
 
                     invalid = true;
+                }
+                else
+                {
+                    final String[] unknownTypes = ResultDataTypes.validate(downloadOptValue);
+                    if (unknownTypes.length > 0)
+                    {
+                        final String message = String.format("Unrecognized values passed as argument to '--%s' option: %s\nSupported values: %s",
+                                                             OPTION_DOWNLOAD, StringUtils.join(unknownTypes, ", "),
+                                                             StringUtils.join(ResultDataTypes.values(), ", "));
+                        System.out.println(message);
+                        log.error(message);
+
+                        invalid = true;
+                    }
                 }
             }
         }
@@ -691,7 +704,15 @@ public class Main
 
         private static String[] parse(final String valueString)
         {
-            return StringUtils.split(valueString, ',');
+            String[] values = StringUtils.split(valueString, ',');
+            if (values != null)
+            {
+                for (int i = 0; i < values.length; i++)
+                {
+                    values[i] = values[i].trim();
+                }
+            }
+            return values;
         }
     }
 }

--- a/src/main/java/com/xceptance/xlt/mastercontroller/NonInteractiveUI.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/NonInteractiveUI.java
@@ -118,6 +118,11 @@ public class NonInteractiveUI extends BasicConsoleUI
     private final MasterControllerCommands[] commands;
 
     /**
+     * The amount of test results to be downloaded.
+     */
+    private final TestResultAmount testResultAmount;
+
+    /**
      * Creates a new {@link NonInteractiveUI} object.
      *
      * @param masterController
@@ -126,13 +131,17 @@ public class NonInteractiveUI extends BasicConsoleUI
      *            a comma-separated list of commands
      * @param agentControllerTimeout
      *            the maximum time [ms] to wait for all agent controllers to become alive
+     * @param resultAmount
+     *            the amount of test results to download
      */
-    public NonInteractiveUI(final MasterController masterController, final String commandList, final long agentControllerTimeout)
+    public NonInteractiveUI(final MasterController masterController, final String commandList, final long agentControllerTimeout,
+                            final TestResultAmount resultAmount)
     {
         super(masterController);
 
         commands = MasterControllerCommands.convert(commandList);
         this.agentControllerTimeout = agentControllerTimeout;
+        this.testResultAmount = resultAmount;
     }
 
     /**
@@ -256,7 +265,7 @@ public class NonInteractiveUI extends BasicConsoleUI
 
     private void download()
     {
-        if (!downloadTestResults(TestResultAmount.ALL))
+        if (!downloadTestResults(testResultAmount))
         {
             throw new XltException("Downloading test results failed.");
         }

--- a/src/main/java/com/xceptance/xlt/mastercontroller/ResultDownloader.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/ResultDownloader.java
@@ -95,7 +95,7 @@ public class ResultDownloader
         archiveResults(testResultAmount);
 
         // download and unzip archives
-        final boolean resultsDownloaded = downloadResults(testResultAmount, compressedTimerFiles);
+        final boolean resultsDownloaded = downloadResults(compressedTimerFiles);
 
         // We have downloaded results from at least 1 agent controller.
         // AND
@@ -387,7 +387,7 @@ public class ResultDownloader
     /**
      * @progresscount 5 * ac
      */
-    private boolean downloadResults(final TestResultAmount testResultAmount, final boolean compressedTimerFiles)
+    private boolean downloadResults(final boolean compressedTimerFiles)
     {
         LOG.debug("Download results");
         try
@@ -401,7 +401,7 @@ public class ResultDownloader
                     {
                         // download the archive
                         LOG.debug("Downloading results from " + agentController);
-                        downloadTestResults(agentController, testResultAmount, compressedTimerFiles);
+                        downloadTestResults(agentController, compressedTimerFiles);
                         LOG.debug("Downloading results from " + agentController + " OK");
                         return true;
                     }
@@ -480,15 +480,11 @@ public class ResultDownloader
      *            the target directory
      * @param agentController
      *            the target agent controller
-     * @param testResultAmount
-     *            the amount of test result data to download
      * @throws java.io.IOException
      *             if an I/O error occurs
      * @progresscount 4
      */
-    private void downloadTestResults(final AgentController agentController, final TestResultAmount testResultAmount,
-                                     final boolean compressedTimerFiles)
-        throws IOException
+    private void downloadTestResults(final AgentController agentController, final boolean compressedTimerFiles) throws IOException
     {
         /** agentID, downloadedZipFile */
         final Map<String, File> downloadedZipFiles = new HashMap<String, File>();


### PR DESCRIPTION
Implemented new option `--only-download` that can be used to restrict result download to the given data types (comma-separated list). Supported values are `logs`, `measurements` and `resultbrowsers`.

Example: `mastercontroller.sh -auto -embedded --only-download=measurements,logs`