### PR TITLE
#137: Improve cookie selection for OkHttp-based web connection

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImpl.java
@@ -108,7 +108,7 @@ class CookieJarImpl implements CookieJar
         {
             // "wildcard" domain, such as ".example.com"
             // the cookie builder expects the domain to be passed without the leading dot
-            builder.domain(StringUtils.stripStart(htmlUnitCookie.getDomain(), "."));
+            builder.domain(StringUtils.stripStart(domain, "."));
         }
         else
         {


### PR DESCRIPTION
- reuse logic from OkHttp to decide whether a cookie is to be sent back to a certain server
- handle host/wildcard domains consistently when converting cookies from/to HtmlUnit