### PR TITLE
#166: Result Browser does not show JSON view for content type application/vnd.api+json

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/assets/js/resultbrowser.js
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/assets/js/resultbrowser.js
@@ -438,7 +438,8 @@
                             $('#highlightSyntax').prop('disabled', !extras.highlight);
                             $requestText.text(data).removeClass().addClass(lang ? ('language-'+lang+' '+lang) : 'text').show();
 
-                            if (requestData.mimeType === 'application/json') {
+                            // feed the json viewer if the mime type indicates json-ish content (e.g. "application/json" or "application/<...>+json")
+                            if (requestData.mimeType.match(/^application\/(.+\+)?json$/) !== null) {
                                 jsonView.format(data, '#jsonViewerContent');
                             }
                         },

--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/assets/js/resultbrowser.js
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/assets/js/resultbrowser.js
@@ -439,7 +439,7 @@
                             $requestText.text(data).removeClass().addClass(lang ? ('language-'+lang+' '+lang) : 'text').show();
 
                             // feed the json viewer if the mime type indicates json-ish content (e.g. "application/json" or "application/<...>+json")
-                            if (requestData.mimeType.match(/^application\/(.+\+)?json$/) !== null) {
+                            if (/^application\/(.+\+)?json$/.test(requestData.mimeType)) {
                                 jsonView.format(data, '#jsonViewerContent');
                             }
                         },


### PR DESCRIPTION
Also feed the json viewer if the mime type indicates json-ish content, i.e. accept not only "application/json", but also "application/<...>+json".