### PR TITLE
57: Hide credentials passed in the URL in the load test report

### DIFF
--- a/samples/testsuite-performance/config/default.properties
+++ b/samples/testsuite-performance/config/default.properties
@@ -332,6 +332,12 @@ com.xceptance.xlt.result-dir = ./results
 ## only if really needed since the amount of result data will increase.
 #com.xceptance.xlt.results.data.request.collectAdditionalRequestInfo = true
 
+## Whether to automatically remove any present user-info from the request's URL
+## in order to hide sensitive data (default: true). This should not be disabled
+## unless you know what you are doing and rely on this information to be
+## present (e.g. for debugging purposes).
+com.xceptance.xlt.results.data.request.removeUserInfoFromURL = true
+
 ## Whether to automatically open the result browser in the default Web browser
 ## after a test case has finished (default: false). Will be effective in dev
 ## mode only, i.e. when running tests from within your IDE.

--- a/samples/testsuite-posters/config/default.properties
+++ b/samples/testsuite-posters/config/default.properties
@@ -332,6 +332,12 @@ com.xceptance.xlt.result-dir = ./results
 ## only if really needed since the amount of result data will increase.
 #com.xceptance.xlt.results.data.request.collectAdditionalRequestInfo = true
 
+## Whether to automatically remove any present user-info from the request's URL
+## in order to hide sensitive data (default: true). This should not be disabled
+## unless you know what you are doing and rely on this information to be
+## present (e.g. for debugging purposes).
+com.xceptance.xlt.results.data.request.removeUserInfoFromURL = true
+
 ## Whether to automatically open the result browser in the default Web browser
 ## after a test case has finished (default: false). Will be effective in dev
 ## mode only, i.e. when running tests from within your IDE.

--- a/samples/testsuite-showcases/config/default.properties
+++ b/samples/testsuite-showcases/config/default.properties
@@ -332,6 +332,12 @@ com.xceptance.xlt.result-dir = ./results
 ## only if really needed since the amount of result data will increase.
 #com.xceptance.xlt.results.data.request.collectAdditionalRequestInfo = true
 
+## Whether to automatically remove any present user-info from the request's URL
+## in order to hide sensitive data (default: true). This should not be disabled
+## unless you know what you are doing and rely on this information to be
+## present (e.g. for debugging purposes).
+com.xceptance.xlt.results.data.request.removeUserInfoFromURL = true
+
 ## Whether to automatically open the result browser in the default Web browser
 ## after a test case has finished (default: false). Will be effective in dev
 ## mode only, i.e. when running tests from within your IDE.

--- a/samples/testsuite-template/config/default.properties
+++ b/samples/testsuite-template/config/default.properties
@@ -332,6 +332,12 @@ com.xceptance.xlt.result-dir = ./results
 ## only if really needed since the amount of result data will increase.
 #com.xceptance.xlt.results.data.request.collectAdditionalRequestInfo = true
 
+## Whether to automatically remove any present user-info from the request's URL
+## in order to hide sensitive data (default: true). This should not be disabled
+## unless you know what you are doing and rely on this information to be
+## present (e.g. for debugging purposes).
+com.xceptance.xlt.results.data.request.removeUserInfoFromURL = true
+
 ## Whether to automatically open the result browser in the default Web browser
 ## after a test case has finished (default: false). Will be effective in dev
 ## mode only, i.e. when running tests from within your IDE.

--- a/samples/testsuite-xlt/config/default.properties
+++ b/samples/testsuite-xlt/config/default.properties
@@ -332,6 +332,12 @@ com.xceptance.xlt.result-dir = ./results
 ## only if really needed since the amount of result data will increase.
 #com.xceptance.xlt.results.data.request.collectAdditionalRequestInfo = true
 
+## Whether to automatically remove any present user-info from the request's URL
+## in order to hide sensitive data (default: true). This should not be disabled
+## unless you know what you are doing and rely on this information to be
+## present (e.g. for debugging purposes).
+com.xceptance.xlt.results.data.request.removeUserInfoFromURL = true
+
 ## Whether to automatically open the result browser in the default Web browser
 ## after a test case has finished (default: false). Will be effective in dev
 ## mode only, i.e. when running tests from within your IDE.

--- a/src/main/java/com/xceptance/xlt/clientperformance/PerformanceDataTransformator.java
+++ b/src/main/java/com/xceptance/xlt/clientperformance/PerformanceDataTransformator.java
@@ -32,6 +32,7 @@ import com.xceptance.xlt.api.engine.PageLoadTimingData;
 import com.xceptance.xlt.api.engine.RequestData;
 import com.xceptance.xlt.engine.GlobalClockImpl;
 import com.xceptance.xlt.engine.SessionImpl;
+import com.xceptance.xlt.engine.util.URLCleaner;
 import com.xceptance.xlt.engine.util.UrlUtils;
 
 public final class PerformanceDataTransformator
@@ -272,7 +273,7 @@ public final class PerformanceDataTransformator
         final RequestData requestData = performanceRequest.getRequestData();
 
         requestData.setName(request.getString("requestId"));
-        requestData.setUrl(request.getString("url"));
+        requestData.setUrl(URLCleaner.removeUserInfoIfNecessaryAsString(request.getString("url")));
 
         requestData.setContentType(cleanContentType(request.optString("contentType")));
         final int statusCode = request.optInt("statusCode", 0);
@@ -298,11 +299,6 @@ public final class PerformanceDataTransformator
             requestData.setHttpMethod(performanceRequest.getHttpMethod());
             requestData.setFormData(performanceRequest.getFormData());
             requestData.setFormDataEncoding(performanceRequest.getFormDataEncoding());
-        }
-        // remove user-info from request URL if we need to (GH #57)
-        if(SessionImpl.REMOVE_USERINFO_FROM_REQUEST_URL)
-        {
-            requestData.setUrl(UrlUtils.removeUserInfo(requestData.getUrl()));
         }
     }
 

--- a/src/main/java/com/xceptance/xlt/clientperformance/PerformanceDataTransformator.java
+++ b/src/main/java/com/xceptance/xlt/clientperformance/PerformanceDataTransformator.java
@@ -299,6 +299,11 @@ public final class PerformanceDataTransformator
             requestData.setFormData(performanceRequest.getFormData());
             requestData.setFormDataEncoding(performanceRequest.getFormDataEncoding());
         }
+        // remove user-info from request URL if we need to (GH #57)
+        if(SessionImpl.REMOVE_USERINFO_FROM_REQUEST_URL)
+        {
+            requestData.setUrl(UrlUtils.removeUserInfo(requestData.getUrl()));
+        }
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/engine/SessionImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/SessionImpl.java
@@ -106,6 +106,16 @@ public class SessionImpl extends Session
      */
     public static final boolean COLLECT_ADDITIONAL_REQUEST_DATA;
 
+    /**
+     * Global flag that controls whether or not to remove user-info from request URLs.
+     */
+    public static final boolean REMOVE_USERINFO_FROM_REQUEST_URL;
+
+    /**
+     * Name of the removeUserInfoFromURL property.
+     */
+    private static final String PROP_REMOVE_USERINFO_FROM_REQUEST_URL = XltConstants.XLT_PACKAGE_PATH + ".results.data.request.removeUserInfoFromURL";
+
     static
     {
         final XltProperties props = XltProperties.getInstance();
@@ -121,6 +131,7 @@ public class SessionImpl extends Session
         }
 
         COLLECT_ADDITIONAL_REQUEST_DATA = props.getProperty(PROP_COLLECT_ADDITIONAL_REQUEST_DATA, false);
+        REMOVE_USERINFO_FROM_REQUEST_URL = props.getProperty(PROP_REMOVE_USERINFO_FROM_REQUEST_URL, true);
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/engine/XltHttpWebConnection.java
+++ b/src/main/java/com/xceptance/xlt/engine/XltHttpWebConnection.java
@@ -247,7 +247,7 @@ public class XltHttpWebConnection extends CachingHttpWebConnection
         {
             // create new statistics and set request data
             requestData = new RequestData(timerName);
-            requestData.setUrl(webRequest.getUrl().toString());
+            requestData.setUrl(removeUserInfoIfNecessary(webRequest.getUrl()));
 
             putAdditionalRequestData(requestData, webRequest);
 
@@ -443,7 +443,7 @@ public class XltHttpWebConnection extends CachingHttpWebConnection
         if (statusCode == 0 || statusCode >= 400)
         {
             final String eventName = "Failed to download resource";
-            final String message = String.format("[%d] %s", statusCode, url);
+            final String message = String.format("[%d] %s", statusCode, removeUserInfoIfNecessary(url));
 
             // log event
             Session.getCurrent().getDataManager().logEvent(eventName, message);
@@ -485,5 +485,18 @@ public class XltHttpWebConnection extends CachingHttpWebConnection
                 }
             }
         }
+    }
+
+    protected static String removeUserInfoIfNecessary(final URL url)
+    {
+        String urlString = url.toExternalForm();
+
+        // remove user-info from request URL if we need to (GH #57)
+        if(SessionImpl.REMOVE_USERINFO_FROM_REQUEST_URL)
+        {
+            urlString = UrlUtils.removeUserInfo(urlString);
+        }
+
+        return urlString;
     }
 }

--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/DumpMgr.java
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/DumpMgr.java
@@ -59,8 +59,10 @@ import com.xceptance.xlt.common.XltConstants;
 import com.xceptance.xlt.engine.LightWeightPageImpl;
 import com.xceptance.xlt.engine.SessionImpl;
 import com.xceptance.xlt.engine.XltEngine;
+import com.xceptance.xlt.engine.XltHttpWebConnection;
 import com.xceptance.xlt.engine.har.HarWriter;
 import com.xceptance.xlt.engine.util.CssUtils;
+import com.xceptance.xlt.engine.util.URLCleaner;
 
 /**
  * Manager responsible for dumping all kind of requests.
@@ -781,7 +783,9 @@ class DumpMgr
      */
     private void dumpStaticContentToCache(final WebRequest webRequest, final WebResponse webResponse)
     {
-        String fileName = urlMapping.map(webRequest.isRedirected() ? webRequest.getOriginalURL() : webRequest.getUrl());
+        final URL url = URLCleaner.removeUserInfoIfNecessaryAsURL(webRequest.isRedirected() ? webRequest.getOriginalURL() : webRequest.getUrl());
+
+        String fileName = urlMapping.map(url);
 
         // shorten file name if necessary
         if (fileName.length() > FILENAME_LENGTH_LIMIT)
@@ -799,7 +803,7 @@ class DumpMgr
             }
             else
             {
-                try (final InputStream content = rewriteResponseIfCss(webResponse))
+                try (final InputStream content = rewriteResponseIfCss(url, webResponse))
                 {
                     FileUtils.copyInputStreamToFile(content, file);
                 }
@@ -815,12 +819,14 @@ class DumpMgr
      * Rewrites the content of the given response if its URL refers to a CSS file. Otherwise, the response's content
      * will be kept unmodified. Finally, the response's content will be returned as stream.
      *
+     * @param baseURL
+     *            the URL to use for resolving CSS url strings
      * @param response
      *            the response
      * @return content of response (rewritten or original) as stream
      * @throws IOException
      */
-    private InputStream rewriteResponseIfCss(final WebResponse response) throws IOException
+    private InputStream rewriteResponseIfCss(final URL baseURL, final WebResponse response) throws IOException
     {
         if (CssUtils.isCssResponse(response))
         {
@@ -828,9 +834,6 @@ class DumpMgr
             if (responseData != null)
             {
                 final Collection<String> toBeReplaced = CssUtils.getUrlStrings(responseData);
-
-                final URL baseURL = response.getWebRequest().isRedirected() ? response.getWebRequest().getOriginalURL()
-                                                                            : response.getWebRequest().getUrl();
 
                 for (final String urlString : toBeReplaced)
                 {

--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/PageDOMClone.java
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/PageDOMClone.java
@@ -34,6 +34,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlHead;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.xceptance.xlt.engine.XltWebClient;
+import com.xceptance.xlt.engine.util.URLCleaner;
 
 /**
  * DOM clone of a HTML page.
@@ -81,7 +82,7 @@ class PageDOMClone
         handleMissingSlashes = htmlPage.hasFeature(BrowserVersionFeatures.URL_MISSING_SLASHES);
         frames = new HashMap<Element, PageDOMClone>();
         response = htmlPage.getWebResponse();
-        baseURL = determineBaseURL(htmlPage);
+        baseURL = URLCleaner.removeUserInfoIfNecessaryAsURL(determineBaseURL(htmlPage));
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/PageTransformer.java
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/PageTransformer.java
@@ -43,10 +43,12 @@ import com.xceptance.common.xml.DomUtils;
 import com.xceptance.xlt.api.htmlunit.LightWeightPage;
 import com.xceptance.xlt.common.XltConstants;
 import com.xceptance.xlt.engine.LightWeightPageImpl;
+import com.xceptance.xlt.engine.XltHttpWebConnection;
 import com.xceptance.xlt.engine.XltWebClient;
 import com.xceptance.xlt.engine.util.CssUtils;
 import com.xceptance.xlt.engine.util.LWPageUtilities;
 import com.xceptance.xlt.engine.util.TimerUtils;
+import com.xceptance.xlt.engine.util.URLCleaner;
 
 /**
  * Transforms a given page for local storage.
@@ -365,6 +367,8 @@ final class PageTransformer
                 baseURL = u;
             }
         }
+        
+        baseURL = URLCleaner.removeUserInfoIfNecessaryAsURL(baseURL);
 
         // get document charset
         final Charset charset = lwPage.getCharset();

--- a/src/main/java/com/xceptance/xlt/engine/util/URLCleaner.java
+++ b/src/main/java/com/xceptance/xlt/engine/util/URLCleaner.java
@@ -1,0 +1,67 @@
+package com.xceptance.xlt.engine.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.log4j.Logger;
+
+import com.xceptance.xlt.api.util.XltLogger;
+import com.xceptance.xlt.engine.SessionImpl;
+
+public final class URLCleaner
+{
+    /**
+     * Default constructor. Declared private to prevent external instantiation.
+     */
+    private URLCleaner()
+    {
+    }
+
+    public static URL removeUserInfoIfNecessaryAsURL(final URL url)
+    {
+        // remove user-info from request URL if we need to (GH #57)
+        if (SessionImpl.REMOVE_USERINFO_FROM_REQUEST_URL)
+        {
+            try
+            {
+                return UrlUtils.getURLWithoutUserInfo(url);
+            }
+            catch (final MalformedURLException mue)
+            {
+                final Logger logger = XltLogger.runTimeLogger;
+                if (logger.isInfoEnabled())
+                {
+                    logger.error(String.format("Failed to remove user-info from URL '%s'", url), mue);
+                }
+            }
+        }
+
+        // return URL as is
+        return url;
+    }
+
+    public static String removeUserInfoIfNecessaryAsString(final URL url)
+    {
+        // remove user-info from request URL if we need to (GH #57)
+        if (SessionImpl.REMOVE_USERINFO_FROM_REQUEST_URL)
+        {
+            return UrlUtils.removeUserInfo(url);
+        }
+
+        // return URL as string
+        return url.toExternalForm();
+    }
+
+    public static String removeUserInfoIfNecessaryAsString(final String url)
+    {
+        // remove user-info from request URL if we need to (GH #57)
+        if (SessionImpl.REMOVE_USERINFO_FROM_REQUEST_URL)
+        {
+            return UrlUtils.removeUserInfo(url);
+        }
+
+        // return URL string as is
+        return url;
+    }
+
+}

--- a/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
+++ b/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
@@ -239,7 +239,11 @@ public final class UrlUtils
         if (info != null)
         {
             final StringBuilder sb = new StringBuilder();
-            sb.append(info.getProtocol()).append("://").append(info.getHost());
+            if(info.getProtocol() != null)
+            {
+                sb.append(info.getProtocol()).append("://");
+            }
+            sb.append(info.getHost());
             if (info.getPort() > -1)
             {
                 sb.append(':').append(info.getPort());

--- a/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
+++ b/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
@@ -233,7 +233,7 @@ public final class UrlUtils
      *            the URL string
      * @return given URL string without user-info part
      */
-    public static String removeUserInfo(String url)
+    public static String removeUserInfo(final String url)
     {
         final URLInfo info = StringUtils.isNotBlank(url) ? parseUrlString(url) : null;
         if (info != null)
@@ -258,4 +258,37 @@ public final class UrlUtils
 
         return null;
     }
+
+    /**
+     * Removes the user-info part from the given URL.
+     * 
+     * @param url
+     *            the URL
+     * @return given URL as string without user-info part
+     */
+    public static String removeUserInfo(final URL url)
+    {
+        if (url != null)
+        {
+            final StringBuilder sb = new StringBuilder();
+            sb.append(url.getProtocol()).append("://").append(url.getHost());
+            if (url.getPort() > 0)
+            {
+                sb.append(':').append(url.getPort());
+            }
+            sb.append(url.getPath());
+            if (url.getQuery() != null)
+            {
+                sb.append('?').append(url.getQuery());
+            }
+            if (url.getRef() != null)
+            {
+                sb.append('#').append(url.getRef());
+            }
+            return sb.toString();
+        }
+
+        return null;
+    }
+
 }

--- a/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
+++ b/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
@@ -240,7 +240,7 @@ public final class UrlUtils
         {
             final StringBuilder sb = new StringBuilder();
             sb.append(info.getProtocol()).append("://").append(info.getHost());
-            if (info.getPort() > 0)
+            if (info.getPort() > -1)
             {
                 sb.append(':').append(info.getPort());
             }
@@ -272,7 +272,7 @@ public final class UrlUtils
         {
             final StringBuilder sb = new StringBuilder();
             sb.append(url.getProtocol()).append("://").append(url.getHost());
-            if (url.getPort() > 0)
+            if (url.getPort() > -1)
             {
                 sb.append(':').append(url.getPort());
             }

--- a/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
+++ b/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
@@ -141,7 +141,7 @@ public final class UrlUtils
 
         parts = split(authorityPath, "/", true);
         authority = parts[0];
-        path = (parts[1] == null) ? "/" : "/" + parts[1];
+        path = (parts[1] == null) ? StringUtils.EMPTY : "/" + parts[1];
 
         parts = split(authority, "@", false);
         userInfo = parts[0];
@@ -202,7 +202,9 @@ public final class UrlUtils
     }
 
     /**
-     * Convert a list of name value pairs into an URL encoded parameter string. </br></br> <b>For example:</b>
+     * Convert a list of name value pairs into an URL encoded parameter string. </br>
+     * </br>
+     * <b>For example:</b>
      * 
      * <pre>
      * List&ltNameValuePair&gt parameters = new ArrayList&lt&gt();
@@ -222,5 +224,38 @@ public final class UrlUtils
     {
         final List<org.apache.http.NameValuePair> httpClientPairs = NameValuePair.toHttpClient(parameters);
         return URLEncodedUtils.format(httpClientPairs, XltConstants.UTF8_ENCODING);
+    }
+
+    /**
+     * Removes the user-info part from the given URL string.
+     * 
+     * @param url
+     *            the URL string
+     * @return given URL string without user-info part
+     */
+    public static String removeUserInfo(String url)
+    {
+        final URLInfo info = StringUtils.isNotBlank(url) ? parseUrlString(url) : null;
+        if (info != null)
+        {
+            final StringBuilder sb = new StringBuilder();
+            sb.append(info.getProtocol()).append("://").append(info.getHost());
+            if (info.getPort() > 0)
+            {
+                sb.append(':').append(info.getPort());
+            }
+            sb.append(info.getPath());
+            if (info.getQuery() != null)
+            {
+                sb.append('?').append(info.getQuery());
+            }
+            if (info.getFragment() != null)
+            {
+                sb.append('#').append(info.getFragment());
+            }
+            return sb.toString();
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
+++ b/src/main/java/com/xceptance/xlt/engine/util/UrlUtils.java
@@ -228,7 +228,7 @@ public final class UrlUtils
 
     /**
      * Removes the user-info part from the given URL string.
-     * 
+     *
      * @param url
      *            the URL string
      * @return given URL string without user-info part
@@ -261,7 +261,7 @@ public final class UrlUtils
 
     /**
      * Removes the user-info part from the given URL.
-     * 
+     *
      * @param url
      *            the URL
      * @return given URL as string without user-info part
@@ -288,6 +288,32 @@ public final class UrlUtils
             return sb.toString();
         }
 
+        return null;
+    }
+
+    /**
+     * Returns the given URL without the user-info part.
+     *
+     * @param url
+     *            the URL
+     * @return given URL without user-info part
+     * @throws MalformedURLException
+     */
+    public static URL getURLWithoutUserInfo(final URL url) throws MalformedURLException
+    {
+        if (url != null)
+        {
+            String file = url.getPath();
+            if (url.getQuery() != null)
+            {
+                file += "?" + url.getQuery();
+            }
+            if (url.getRef() != null)
+            {
+                file += "#" + url.getRef();
+            }
+            return new URL(url.getProtocol(), url.getHost(), url.getPort(), file, null);
+        }
         return null;
     }
 

--- a/src/test/java/com/xceptance/xlt/engine/util/UrlUtilsTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/util/UrlUtilsTest.java
@@ -45,7 +45,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertNull(info.getFragment());
     }
@@ -60,7 +60,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("foo.bar", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertNull(info.getFragment());
     }
@@ -75,7 +75,7 @@ public class UrlUtilsTest
         Assert.assertEquals("john:doe", info.getUserInfo());
         Assert.assertEquals("foo.bar", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertNull(info.getFragment());
     }
@@ -90,7 +90,7 @@ public class UrlUtilsTest
         Assert.assertEquals("john:doe", info.getUserInfo());
         Assert.assertEquals("", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertNull(info.getFragment());
     }
@@ -105,7 +105,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("example.org", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertNull(info.getFragment());
     }
@@ -120,7 +120,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("example.org", info.getHost());
         Assert.assertEquals(999, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertNull(info.getFragment());
     }
@@ -165,7 +165,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertEquals("fooBar", info.getFragment());
     }
@@ -180,7 +180,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("example.org", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertNull(info.getQuery());
         Assert.assertEquals("fooBar", info.getFragment());
     }
@@ -195,7 +195,7 @@ public class UrlUtilsTest
         Assert.assertNull(info.getUserInfo());
         Assert.assertEquals("", info.getHost());
         Assert.assertEquals(-1, info.getPort());
-        Assert.assertEquals("/", info.getPath());
+        Assert.assertEquals("", info.getPath());
         Assert.assertEquals("foo=bar", info.getQuery());
         Assert.assertEquals("fooBar", info.getFragment());
     }
@@ -284,7 +284,7 @@ public class UrlUtilsTest
         Assert.assertEquals("http", url.getProtocol());
         Assert.assertNull(url.getUserInfo());
         Assert.assertEquals("example.org", url.getHost());
-        Assert.assertEquals("/", url.getPath());
+        Assert.assertEquals("", url.getPath());
         Assert.assertNull(url.getQuery());
         Assert.assertNull(url.getRef());
         Assert.assertEquals(-1, url.getPort());
@@ -338,5 +338,42 @@ public class UrlUtilsTest
         Assert.assertEquals("/css", info.getPath());
         Assert.assertEquals("family=Roboto:400,300,500,300italic|Inconsolata:400,700", info.getQuery());
         Assert.assertEquals(null, info.getFragment());
+    }
+
+    @Test
+    public void testRemoveUserInfo_NullOrBlank() throws Throwable
+    {
+        final String message = "Blank or null input string should return null";
+        Assert.assertNull(message, UrlUtils.removeUserInfo(null));
+        Assert.assertNull(message, UrlUtils.removeUserInfo(""));
+        Assert.assertNull(message, UrlUtils.removeUserInfo("    "));
+    }
+
+    @Test
+    public void testRemoveUserInfo_NoUserInfo() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo("https://anyserver.com:12345/some/path?foo=bar#fragment"));
+    }
+
+    @Test
+    public void testRemoveUserInfo_UserNameOnly() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo("https://johndoe@anyserver.com:12345/some/path?foo=bar#fragment"));
+    }
+
+    @Test
+    public void testRemoveUserInfo_EmptyPassword() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo("https://johndoe:@anyserver.com:12345/some/path?foo=bar#fragment"));
+    }
+
+    @Test
+    public void testRemoveUserInfo_UserNameAndPassword() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo("https://johndoe:secret@anyserver.com:12345/some/path?foo=bar#fragment"));
     }
 }

--- a/src/test/java/com/xceptance/xlt/engine/util/UrlUtilsTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/util/UrlUtilsTest.java
@@ -344,7 +344,7 @@ public class UrlUtilsTest
     public void testRemoveUserInfo_NullOrBlank() throws Throwable
     {
         final String message = "Blank or null input string should return null";
-        Assert.assertNull(message, UrlUtils.removeUserInfo(null));
+        Assert.assertNull(message, UrlUtils.removeUserInfo((String) null));
         Assert.assertNull(message, UrlUtils.removeUserInfo(""));
         Assert.assertNull(message, UrlUtils.removeUserInfo("    "));
     }
@@ -376,4 +376,38 @@ public class UrlUtilsTest
         Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
                             UrlUtils.removeUserInfo("https://johndoe:secret@anyserver.com:12345/some/path?foo=bar#fragment"));
     }
+    @Test
+    public void testRemoveUserInfo_URLNull() throws Throwable
+    {
+        Assert.assertNull("Null input URL should return null", UrlUtils.removeUserInfo((URL) null));
+    }
+
+    @Test
+    public void testRemoveUserInfo_URLNoUserInfo() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo(new URL("https://anyserver.com:12345/some/path?foo=bar#fragment")));
+    }
+
+    @Test
+    public void testRemoveUserInfo_URLUserNameOnly() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo(new URL("https://johndoe@anyserver.com:12345/some/path?foo=bar#fragment")));
+    }
+
+    @Test
+    public void testRemoveUserInfo_URLEmptyPassword() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo(new URL("https://johndoe:@anyserver.com:12345/some/path?foo=bar#fragment")));
+    }
+
+    @Test
+    public void testRemoveUserInfo_URLUserNameAndPassword() throws Throwable
+    {
+        Assert.assertEquals("https://anyserver.com:12345/some/path?foo=bar#fragment",
+                            UrlUtils.removeUserInfo(new URL("https://johndoe:secret@anyserver.com:12345/some/path?foo=bar#fragment")));
+    }
+
 }


### PR DESCRIPTION
- introduce new property to control whether or not to remove user-info from request URL
- remove user-info from request URL if need to do so before writing timer data to CSV
- added tests for new method 'removeUserInfo' of utility class 'com.xceptance.xlt.engine.util.UrlUtils'
- added documentation of new property to all 'default.properties' files in sample test suites