### PR TITLE
#208: "Unexpected end of ZLIB input stream" error when downloading results

### DIFF
--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
@@ -102,7 +102,7 @@ public class FileManagerServlet extends HttpServlet
                 in = new FileInputStream(file);
 
                 resp.setStatus(HttpServletResponse.SC_OK);
-                resp.setHeader("Content-Length", String.valueOf(file.length()));
+                resp.setContentLengthLong(file.length());
                 
                 final OutputStream out = resp.getOutputStream();
 

--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
@@ -101,14 +101,12 @@ public class FileManagerServlet extends HttpServlet
                 final File file = new File(rootDirectory, fileName);
                 in = new FileInputStream(file);
 
-                resp.setContentLength((int) file.length());
-                // resp.setContentType("???");
-
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.setHeader("Content-Length", String.valueOf(file.length()));
+                
                 final OutputStream out = resp.getOutputStream();
 
                 IOUtils.copy(in, out);
-
-                resp.setStatus(HttpServletResponse.SC_OK);
             }
         }
         catch (final Exception ex)


### PR DESCRIPTION
- add content length header manually as the servlet API method allows int values only