### PR TITLE
GH #213: ClassCastException while trying to use XLT's client-performane webdriver in screenless mode

### DIFF
--- a/src/main/java/com/xceptance/xlt/api/webdriver/XltChromeDriver.java
+++ b/src/main/java/com/xceptance/xlt/api/webdriver/XltChromeDriver.java
@@ -17,6 +17,7 @@ package com.xceptance.xlt.api.webdriver;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -362,7 +363,7 @@ public class XltChromeDriver extends ChromeDriver
                 // HACK: we can access the service's environment settings via reflection only
 
                 // read the environment settings
-                final ImmutableMap<String, String> environment = ReflectionUtils.readField(ChromeDriverService.class, service,
+                final Map<String, String> environment = ReflectionUtils.readField(ChromeDriverService.class, service,
                                                                                            FIELD_NAME_ENVIRONMENT);
 
                 // create the new environment settings including the DISPLAY variable

--- a/src/main/java/com/xceptance/xlt/api/webdriver/XltFirefoxDriver.java
+++ b/src/main/java/com/xceptance/xlt/api/webdriver/XltFirefoxDriver.java
@@ -17,6 +17,7 @@ package com.xceptance.xlt.api.webdriver;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -416,7 +417,7 @@ public final class XltFirefoxDriver extends FirefoxDriver
                  */
 
                 // read the environment settings
-                final ImmutableMap<String, String> environment = ReflectionUtils.readField(DriverService.class, service,
+                final Map<String, String> environment = ReflectionUtils.readField(DriverService.class, service,
                                                                                            FIELD_NAME_ENVIRONMENT);
 
                 // create the new environment settings including the DISPLAY variable


### PR DESCRIPTION
Changes:
- adjusted `XltFirefoxDriver` and `XltChromeDriver` to cast value of DriverService's 'environment' field java.util.Map instead of com.google.common.collect.ImmutableMap

Fixes #213 