### PR TITLE
#222: Run start command independently from upload command

### DIFF
--- a/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerProxy.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerProxy.java
@@ -67,7 +67,8 @@ public class AgentControllerProxy extends AgentControllerImpl
      * @param urlConnectionFactory
      */
     public AgentControllerProxy(final Properties commandLineProperties, final HessianProxyFactory proxyFactory,
-                                final UrlConnectionFactory urlConnectionFactory) throws Exception
+                                final UrlConnectionFactory urlConnectionFactory)
+        throws Exception
     {
         super(commandLineProperties);
 
@@ -98,9 +99,12 @@ public class AgentControllerProxy extends AgentControllerImpl
      */
     @Override
     public void init(final String name, final URL url, final int weight, final int agentCount, final int agentBaseNumber,
-                     final boolean runsClientPerformanceTests) throws IOException
+                     final boolean runsClientPerformanceTests)
+        throws IOException
     {
         super.init(name, url, weight, agentCount, agentBaseNumber, runsClientPerformanceTests);
+
+        setupAgentManagers();
 
         // start proxy
         startProxy(getUrl());
@@ -288,7 +292,6 @@ public class AgentControllerProxy extends AgentControllerImpl
     @Override
     public void updateAgentFiles(final String agentFilesZipFileName, final List<File> filesToBeDeleted) throws IOException
     {
-        setupAgentManagers();
         getAgentController().updateAgentFiles(agentFilesZipFileName, filesToBeDeleted);
     }
 

--- a/src/main/java/com/xceptance/xlt/mastercontroller/BasicConsoleUI.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/BasicConsoleUI.java
@@ -1084,11 +1084,13 @@ public abstract class BasicConsoleUI implements MasterControllerUI
      * @param testCaseName
      *            the name of the test case to start the agents for, or <code>null</code> if all active test cases
      *            should be started
+     * @param checkTestSuiteUploaded
+     *            whether to check if the test suite was successfully uploaded before
      * @return <code>true</code> if the operation was successful for all agent controllers; <code>false</code> otherwise
      */
-    public boolean startAgents(final String testCaseName)
+    public boolean startAgents(final String testCaseName, final boolean checkTestSuiteUploaded)
     {
-        if (masterController.areAgentsInSync())
+        if (!checkTestSuiteUploaded || masterController.areAgentsInSync())
         {
             System.out.println("Starting agents... ");
             boolean result = false;
@@ -1099,6 +1101,10 @@ public abstract class BasicConsoleUI implements MasterControllerUI
             catch (final AgentControllerException e)
             {
                 print(e.getFailed());
+            }
+            catch (final Exception e)
+            {
+                print(e);
             }
 
             System.out.println();

--- a/src/main/java/com/xceptance/xlt/mastercontroller/FireAndForgetUI.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/FireAndForgetUI.java
@@ -250,7 +250,7 @@ public class FireAndForgetUI extends BasicConsoleUI
     private void executeTestCase(final String activeTestCaseName)
     {
         // start all agents
-        if (!startAgents(activeTestCaseName))
+        if (!startAgents(activeTestCaseName, true))
         {
             // do not commence with the test
             stopAgents();

--- a/src/main/java/com/xceptance/xlt/mastercontroller/InteractiveUI.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/InteractiveUI.java
@@ -126,7 +126,7 @@ public class InteractiveUI extends BasicConsoleUI
             {
                 if (checkAlive() && !isLoadTestRunning())
                 {
-                    startAgents(null);
+                    startAgents(null, true);
                     printLoadTestSettings();
                 }
             }

--- a/src/main/java/com/xceptance/xlt/mastercontroller/NonInteractiveUI.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/NonInteractiveUI.java
@@ -246,7 +246,7 @@ public class NonInteractiveUI extends BasicConsoleUI
             throw new XltException("There is another load test running.");
         }
 
-        if (!startAgents(null))
+        if (!startAgents(null, false))
         {
             throw new XltException("Starting agents failed.");
         }


### PR DESCRIPTION
* Don't insist on a previous upload in non-interactive mode.
* Ensure master controller can start agents without a previous upload.
* Some small master controller clean-ups (create file filter only once, comments, removed superfluous progress increments).