### PR TITLE
#240: Support alternative logger configuration file formats

### DIFF
--- a/bin/agent.cmd
+++ b/bin/agent.cmd
@@ -22,7 +22,7 @@ set JAVA_OPTIONS=
 rem set JAVA_OPTIONS=%JAVA_OPTIONS% -Djava.endorsed.dirs="%XLT_HOME%"
 set JAVA_OPTIONS=%JAVA_OPTIONS% -Dcom.xceptance.xlt.home="%XLT_HOME%"
 set JAVA_OPTIONS=%JAVA_OPTIONS% -Dcom.xceptance.xlt.agent.home="%AGENT_HOME%"
-set JAVA_OPTIONS=%JAVA_OPTIONS% -Dlog4j2.configurationFile="%AGENT_CONFIG_DIR%\log4j2.properties"
+set JAVA_OPTIONS=%JAVA_OPTIONS% -Dlog4j2.configurationFile="%AGENT_CONFIG_DIR%\log4j2.properties","%AGENT_CONFIG_DIR%\log4j2.yaml","%AGENT_CONFIG_DIR%\log4j2.json","%AGENT_CONFIG_DIR%\log4j2.xml"
 set JAVA_OPTIONS=%JAVA_OPTIONS% -Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
 rem set JAVA_OPTIONS=%JAVA_OPTIONS% -agentlib:jdwp=transport=dt_socket,address=localhost:6666,server=y,suspend=n
 set JAVA_OPTIONS=%JAVA_OPTIONS% -cp "%CLASSPATH%"

--- a/bin/agent.cmd
+++ b/bin/agent.cmd
@@ -22,7 +22,7 @@ set JAVA_OPTIONS=
 rem set JAVA_OPTIONS=%JAVA_OPTIONS% -Djava.endorsed.dirs="%XLT_HOME%"
 set JAVA_OPTIONS=%JAVA_OPTIONS% -Dcom.xceptance.xlt.home="%XLT_HOME%"
 set JAVA_OPTIONS=%JAVA_OPTIONS% -Dcom.xceptance.xlt.agent.home="%AGENT_HOME%"
-set JAVA_OPTIONS=%JAVA_OPTIONS% -Dlog4j2.configurationFile="%AGENT_CONFIG_DIR%\log4j2.properties","%AGENT_CONFIG_DIR%\log4j2.yaml","%AGENT_CONFIG_DIR%\log4j2.json","%AGENT_CONFIG_DIR%\log4j2.xml"
+set JAVA_OPTIONS=%JAVA_OPTIONS% -Dlog4j2.configurationFile="%AGENT_CONFIG_DIR%\log4j2.properties","%AGENT_CONFIG_DIR%\log4j2.xml"
 set JAVA_OPTIONS=%JAVA_OPTIONS% -Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
 rem set JAVA_OPTIONS=%JAVA_OPTIONS% -agentlib:jdwp=transport=dt_socket,address=localhost:6666,server=y,suspend=n
 set JAVA_OPTIONS=%JAVA_OPTIONS% -cp "%CLASSPATH%"

--- a/bin/agent.sh
+++ b/bin/agent.sh
@@ -22,7 +22,7 @@ JAVA_OPTIONS=
 #JAVA_OPTIONS="$JAVA_OPTIONS -Djava.endorsed.dirs=\"$XLT_HOME\""
 JAVA_OPTIONS="$JAVA_OPTIONS -Dcom.xceptance.xlt.home=\"$XLT_HOME\""
 JAVA_OPTIONS="$JAVA_OPTIONS -Dcom.xceptance.xlt.agent.home=\"$AGENT_HOME\""
-JAVA_OPTIONS="$JAVA_OPTIONS -Dlog4j2.configurationFile=\"$AGENT_CONFIG_DIR/log4j2.properties\""
+JAVA_OPTIONS="$JAVA_OPTIONS -Dlog4j2.configurationFile=\"$AGENT_CONFIG_DIR/log4j2.properties\",\"$AGENT_CONFIG_DIR/log4j2.yaml\",\"$AGENT_CONFIG_DIR/log4j2.json\",\"$AGENT_CONFIG_DIR/log4j2.xml\""
 JAVA_OPTIONS="$JAVA_OPTIONS -Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault"
 #JAVA_OPTIONS="$JAVA_OPTIONS -agentlib:jdwp=transport=dt_socket,address=localhost:6666,server=y,suspend=n"
 JAVA_OPTIONS="$JAVA_OPTIONS -cp \"$CLASSPATH\""

--- a/bin/agent.sh
+++ b/bin/agent.sh
@@ -22,7 +22,7 @@ JAVA_OPTIONS=
 #JAVA_OPTIONS="$JAVA_OPTIONS -Djava.endorsed.dirs=\"$XLT_HOME\""
 JAVA_OPTIONS="$JAVA_OPTIONS -Dcom.xceptance.xlt.home=\"$XLT_HOME\""
 JAVA_OPTIONS="$JAVA_OPTIONS -Dcom.xceptance.xlt.agent.home=\"$AGENT_HOME\""
-JAVA_OPTIONS="$JAVA_OPTIONS -Dlog4j2.configurationFile=\"$AGENT_CONFIG_DIR/log4j2.properties\",\"$AGENT_CONFIG_DIR/log4j2.yaml\",\"$AGENT_CONFIG_DIR/log4j2.json\",\"$AGENT_CONFIG_DIR/log4j2.xml\""
+JAVA_OPTIONS="$JAVA_OPTIONS -Dlog4j2.configurationFile=\"$AGENT_CONFIG_DIR/log4j2.properties\",\"$AGENT_CONFIG_DIR/log4j2.xml\""
 JAVA_OPTIONS="$JAVA_OPTIONS -Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault"
 #JAVA_OPTIONS="$JAVA_OPTIONS -agentlib:jdwp=transport=dt_socket,address=localhost:6666,server=y,suspend=n"
 JAVA_OPTIONS="$JAVA_OPTIONS -cp \"$CLASSPATH\""

--- a/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerImpl.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerImpl.java
@@ -1034,7 +1034,8 @@ public class AgentControllerImpl implements AgentController
                     {
                         final IOFileFilter propertiesFilesFilter = FileFilterUtils.suffixFileFilter(XltConstants.PROPERTY_FILE_EXTENSION);
                         final IOFileFilter cfgFilesFilter = FileFilterUtils.suffixFileFilter(XltConstants.CFG_FILE_EXTENSION);
-                        final IOFileFilter extensionFilter = FileFilterUtils.or(propertiesFilesFilter, cfgFilesFilter);
+                        final IOFileFilter xmlFilesFilter = FileFilterUtils.suffixFileFilter(XltConstants.XML_FILE_EXTENSION);
+                        final IOFileFilter extensionFilter = FileFilterUtils.or(propertiesFilesFilter, cfgFilesFilter, xmlFilesFilter);
                         final IOFileFilter filter = FileFilterUtils.and(FileFileFilter.FILE, extensionFilter);
 
                         ZipOutputStream out = null;

--- a/src/main/java/com/xceptance/xlt/common/XltConstants.java
+++ b/src/main/java/com/xceptance/xlt/common/XltConstants.java
@@ -75,6 +75,11 @@ public final class XltConstants
     public static final String CFG_FILE_EXTENSION = ".cfg";
 
     /**
+     * The extension of XML files, such as log4j2.xml.
+     */
+    public static final String XML_FILE_EXTENSION = ".xml";
+
+    /**
      * The name of the system property which holds the agent configuration directory.
      */
     public static final String CONFIG_DIR_PROPERTY = XLT_PACKAGE_PATH + ".agent.config";


### PR DESCRIPTION
Extended property `log4j2.configurationFile` to look for log4j2.yaml, log4j2.json, and log4j2.xml as well.