### PR TITLE
#291: move summary chart above data tables

### DIFF
--- a/config/xsl/loadreport/util/timer-section.xsl
+++ b/config/xsl/loadreport/util/timer-section.xsl
@@ -8,7 +8,6 @@
         <xsl:param name="runtimeIntervalsNode"/>
         <xsl:param name="type"/>
         
-        <!-- <h3 class="no-print">Summary</h3> -->
         <div class="charts">
             <xsl:for-each select="$summaryElement">
                 <!-- There is only one matching node. -->

--- a/config/xsl/loadreport/util/timer-section.xsl
+++ b/config/xsl/loadreport/util/timer-section.xsl
@@ -517,6 +517,17 @@
                 </div>
             </xsl:when>
             <xsl:otherwise>
+            	<h3 class="no-print">Summary</h3>
+                <div class="charts">
+                    <xsl:for-each select="$summaryElement">
+                        <!-- There is only one matching node. -->
+                        <xsl:call-template name="timer-chart">
+                            <xsl:with-param name="directory" select="$directory"/>
+                            <xsl:with-param name="type" select="$type"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
+                </div>
+            
                 <div class="data">
                     <xsl:call-template name="timer-table">
                         <xsl:with-param name="elements" select="$elements"/>
@@ -530,17 +541,7 @@
         </xsl:choose>
 
         <xsl:if test="count($elements) &gt; 0">
-            <div>
-                <h3 class="no-print">Summary</h3>
-                <div class="charts">
-                    <xsl:for-each select="$summaryElement">
-                        <!-- There is only one matching node. -->
-                        <xsl:call-template name="timer-chart">
-                            <xsl:with-param name="directory" select="$directory"/>
-                            <xsl:with-param name="type" select="$type"/>
-                        </xsl:call-template>
-                    </xsl:for-each>
-                </div>
+            <div>            
 
                 <h3 class="no-print">
                     <xsl:if test="$type = 'transaction'">

--- a/config/xsl/loadreport/util/timer-section.xsl
+++ b/config/xsl/loadreport/util/timer-section.xsl
@@ -8,7 +8,7 @@
         <xsl:param name="runtimeIntervalsNode"/>
         <xsl:param name="type"/>
         
-        <h3 class="no-print">Summary</h3>
+        <!-- <h3 class="no-print">Summary</h3> -->
         <div class="charts">
             <xsl:for-each select="$summaryElement">
                 <!-- There is only one matching node. -->

--- a/config/xsl/loadreport/util/timer-section.xsl
+++ b/config/xsl/loadreport/util/timer-section.xsl
@@ -7,6 +7,17 @@
         <xsl:param name="directory"/>
         <xsl:param name="runtimeIntervalsNode"/>
         <xsl:param name="type"/>
+        
+        <h3 class="no-print">Summary</h3>
+        <div class="charts">
+            <xsl:for-each select="$summaryElement">
+                <!-- There is only one matching node. -->
+                <xsl:call-template name="timer-chart">
+                    <xsl:with-param name="directory" select="$directory"/>
+                    <xsl:with-param name="type" select="$type"/>
+                </xsl:call-template>
+            </xsl:for-each>
+        </div>
 
         <xsl:choose>
             <xsl:when test="$type = 'request'">
@@ -517,17 +528,6 @@
                 </div>
             </xsl:when>
             <xsl:otherwise>
-            	<h3 class="no-print">Summary</h3>
-                <div class="charts">
-                    <xsl:for-each select="$summaryElement">
-                        <!-- There is only one matching node. -->
-                        <xsl:call-template name="timer-chart">
-                            <xsl:with-param name="directory" select="$directory"/>
-                            <xsl:with-param name="type" select="$type"/>
-                        </xsl:call-template>
-                    </xsl:for-each>
-                </div>
-            
                 <div class="data">
                     <xsl:call-template name="timer-table">
                         <xsl:with-param name="elements" select="$elements"/>
@@ -541,8 +541,7 @@
         </xsl:choose>
 
         <xsl:if test="count($elements) &gt; 0">
-            <div>            
-
+            <div>
                 <h3 class="no-print">
                     <xsl:if test="$type = 'transaction'">
                         Individual Transactions


### PR DESCRIPTION
While I appreciate this as a learning experience I wonder whether the change will be useful for load testers. I understand that it might be valuable for non-tech users to see the overview graphic first, but for evaluating the report I usually need the data tables more often.