### PR TITLE
Added SVG filter (including UI option to toggle between autoresize)

### DIFF
--- a/resultbrowser/src/css/default.css
+++ b/resultbrowser/src/css/default.css
@@ -85,9 +85,21 @@ body {
     padding-left: 0.5em;
 }
 
+/*
 #menu li:nth-of-type(even) .menu-group {
     border-left: 1px solid gray;
     border-right: 1px solid gray;
+}
+*/
+#menu li:nth-of-type(2) .menu-group {
+    border-left: 1px solid gray;
+    border-right: 1px solid gray;
+}
+
+#menu li:nth-of-type(4) .menu-group {
+    border-left: 1px solid gray;
+    float: left;
+    padding-left: 0.5em;
 }
 
 #menu li {

--- a/resultbrowser/src/index.html
+++ b/resultbrowser/src/index.html
@@ -347,6 +347,23 @@
                         </ul>
                     </div>
                 </li>
+                <li id="svgFilter">
+                    <div class="menu-group">
+                        <div class="menu-group-head filter-all">
+                            <label>
+                                <span class="menu-group-headline">SVG Filter</span>
+                            </label>
+                        </div>
+                        <ul>
+                            <li class="filter-SVG">
+                                <label>
+                                    <span class="selectable"><input id="resizeSVGCheckbox" type="checkbox" name="resizeSVGs" checked="checked" title="SVG"></span>
+                                    <span class="name">Resize SVGs</span>
+                                </label>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
First draft of the feature to autoresize SVGs in the result browse. Can be toggled on/off via a checkbox in the filter section (burger menu). Uses CSS rule on all SVGs without width/height.
The checkbox in the filter menu looks a bit dull since I did not applied the correct CSS styles (border on the left).