### PR TITLE
108 add ip statistics

### DIFF
--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -370,9 +370,9 @@ com.xceptance.xlt.reportgenerator.providers.11 = com.xceptance.xlt.report.provid
 com.xceptance.xlt.reportgenerator.providers.12 = com.xceptance.xlt.report.providers.CustomValuesReportProvider
 com.xceptance.xlt.reportgenerator.providers.13 = com.xceptance.xlt.report.providers.ContentTypesReportProvider
 com.xceptance.xlt.reportgenerator.providers.14 = com.xceptance.xlt.report.providers.HostsReportProvider
-com.xceptance.xlt.reportgenerator.providers.14 = com.xceptance.xlt.report.providers.IpReportProvider
-com.xceptance.xlt.reportgenerator.providers.15 = com.xceptance.xlt.report.providers.SummaryReportProvider
-com.xceptance.xlt.reportgenerator.providers.16 = com.xceptance.xlt.report.providers.PageLoadTimingsReportProvider
+com.xceptance.xlt.reportgenerator.providers.15 = com.xceptance.xlt.report.providers.IpReportProvider
+com.xceptance.xlt.reportgenerator.providers.16 = com.xceptance.xlt.report.providers.SummaryReportProvider
+com.xceptance.xlt.reportgenerator.providers.17 = com.xceptance.xlt.report.providers.PageLoadTimingsReportProvider
 
 
 ###############################################################################

--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -370,6 +370,7 @@ com.xceptance.xlt.reportgenerator.providers.11 = com.xceptance.xlt.report.provid
 com.xceptance.xlt.reportgenerator.providers.12 = com.xceptance.xlt.report.providers.CustomValuesReportProvider
 com.xceptance.xlt.reportgenerator.providers.13 = com.xceptance.xlt.report.providers.ContentTypesReportProvider
 com.xceptance.xlt.reportgenerator.providers.14 = com.xceptance.xlt.report.providers.HostsReportProvider
+com.xceptance.xlt.reportgenerator.providers.14 = com.xceptance.xlt.report.providers.IpReportProvider
 com.xceptance.xlt.reportgenerator.providers.15 = com.xceptance.xlt.report.providers.SummaryReportProvider
 com.xceptance.xlt.reportgenerator.providers.16 = com.xceptance.xlt.report.providers.PageLoadTimingsReportProvider
 

--- a/config/xsl/loadreport/network.xsl
+++ b/config/xsl/loadreport/network.xsl
@@ -22,6 +22,7 @@
 
 <xsl:include href="sections/network.xsl" />
 <xsl:include href="sections/hosts.xsl" />
+<xsl:include href="sections/ips.xsl" />
 <xsl:include href="sections/response-codes.xsl" />
 <xsl:include href="sections/content-types.xsl" />
 
@@ -66,6 +67,16 @@
             -->
             <xsl:call-template name="hosts">
                 <xsl:with-param name="rootNode" select="hosts" />
+                <xsl:with-param name="totalHits" select="general/hits" />
+            </xsl:call-template>
+            
+            <!--
+                ************************************
+                * IPs
+                ************************************
+            -->
+            <xsl:call-template name="ips">
+                <xsl:with-param name="rootNode" select="ips" />
                 <xsl:with-param name="totalHits" select="general/hits" />
             </xsl:call-template>
 

--- a/config/xsl/loadreport/sections/ips.xsl
+++ b/config/xsl/loadreport/sections/ips.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+    <xsl:template name="ips">
+        <xsl:param name="rootNode"/>
+        <xsl:param name="totalHits"/>
+
+        <div class="section" id="hosts">
+            <xsl:call-template name="headline-ips"/>
+
+            <div class="content">
+                <xsl:call-template name="description-ips"/>
+
+                <div class="data">
+                    <table class="table-autosort:0 table-autostripe table-stripeclass:odd">
+                        <thead>
+                            <tr>
+                                <th class="table-sortable:alphanumeric">IP</th>
+                                <th class="table-sortable:numeric">Count</th>
+                                <th class="table-sortable:numeric">Percentage</th>
+                            </tr>
+                        </thead>
+                        <xsl:variable name="count" select="count($rootNode/ip)"/>
+                        <xsl:choose>
+                            <xsl:when test="$count > 0">
+                                <tfoot>
+                                    <tr class="totals">
+                                        <xsl:call-template name="create-totals-td">
+                                            <xsl:with-param name="rows-in-table" select="$count" />
+                                        </xsl:call-template>
+                                        
+                                        <td class="value number">
+                                            <xsl:value-of select="format-number($totalHits, '#,##0')"/>
+                                        </td>
+                                        <td class="value number">
+                                            <xsl:value-of select="format-number(1, '#0.0%')"/>
+                                        </td>
+                                    </tr>
+                                </tfoot>
+                                <tbody>
+                                    <xsl:for-each select="$rootNode/ip">
+                                        <xsl:sort select="ip"/>
+                                        <tr>
+                                            <td class="key">
+                                                <xsl:value-of select="ip"/>
+                                            </td>
+                                            <td class="value">
+                                                <xsl:value-of select="format-number(count, '#,##0')"/>
+                                            </td>
+                                            <td class="value">
+                                                <xsl:value-of select="format-number(count div $totalHits, '#,##0.00%')"/>
+                                            </td>
+                                        </tr>
+                                    </xsl:for-each>
+                                </tbody>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <tfoot>
+                                    <tr>
+                                        <td></td>
+                                        <td></td>
+                                        <td></td>
+                                    </tr>
+                                </tfoot>
+                                <tbody>
+                                    <tr>
+                                        <td class="value text" colspan="3">There are no values to show in this table.</td>
+                                    </tr>
+                                </tbody>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/config/xsl/loadreport/sections/ips.xsl
+++ b/config/xsl/loadreport/sections/ips.xsl
@@ -16,6 +16,7 @@
                         <thead>
                             <tr>
                                 <th class="table-sortable:alphanumeric">IP</th>
+                                <th class="table-sortable:alphanumeric">Host</th>
                                 <th class="table-sortable:numeric">Count</th>
                                 <th class="table-sortable:numeric">Percentage</th>
                             </tr>
@@ -28,6 +29,8 @@
                                         <xsl:call-template name="create-totals-td">
                                             <xsl:with-param name="rows-in-table" select="$count" />
                                         </xsl:call-template>
+                                        
+                                        <td></td>
                                         
                                         <td class="value number">
                                             <xsl:value-of select="format-number($totalHits, '#,##0')"/>
@@ -43,6 +46,9 @@
                                         <tr>
                                             <td class="key">
                                                 <xsl:value-of select="ip"/>
+                                            </td>
+                                            <td class="key">
+                                                <xsl:value-of select="host"/>
                                             </td>
                                             <td class="value">
                                                 <xsl:value-of select="format-number(count, '#,##0')"/>
@@ -60,11 +66,12 @@
                                         <td></td>
                                         <td></td>
                                         <td></td>
+                                        <td></td>
                                     </tr>
                                 </tfoot>
                                 <tbody>
                                     <tr>
-                                        <td class="value text" colspan="3">There are no values to show in this table.</td>
+                                        <td class="value text" colspan="4">There are no values to show in this table.</td>
                                     </tr>
                                 </tbody>
                             </xsl:otherwise>

--- a/config/xsl/loadreport/text/descriptions.xsl
+++ b/config/xsl/loadreport/text/descriptions.xsl
@@ -97,6 +97,18 @@
             </p>
         </div>
     </xsl:template>
+    
+    <!--- ## Description: IPs ## -->
+    <xsl:template name="headline-ips">
+        <h2>IP Addresses</h2>
+    </xsl:template>
+    <xsl:template name="description-ips">
+        <div class="description">
+            <p>
+                See below for a list of all IP addresses that have been used during the test.
+            </p>
+        </div>
+    </xsl:template>
 
     <!--- ## Description: HTTP Response Codes ## -->
     <xsl:template name="headline-http-response-codes">

--- a/src/main/java/com/xceptance/xlt/report/providers/IpReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/IpReport.java
@@ -27,6 +27,11 @@ public class IpReport
      * The ip address.
      */
     public String ip;
+    
+    /**
+     * The hostname associated with this ip.
+     */
+    public String host;
 
     /**
      * The total number of requests to that ip.

--- a/src/main/java/com/xceptance/xlt/report/providers/IpReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/IpReport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2005-2023 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.report.providers;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Represents the total number of requests to a certain ip address.
+ */
+@XStreamAlias("ip")
+public class IpReport
+{
+    /**
+     * The ip address.
+     */
+    public String ip;
+
+    /**
+     * The total number of requests to that ip.
+     */
+    public int count;
+}

--- a/src/main/java/com/xceptance/xlt/report/providers/IpReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/IpReportProvider.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.xceptance.xlt.api.engine.Data;
 import com.xceptance.xlt.api.engine.RequestData;
 import com.xceptance.xlt.api.report.AbstractReportProvider;
@@ -37,6 +39,10 @@ public class IpReportProvider extends AbstractReportProvider
      * The value to show if the IP list for the request was empty.
      */
     private static final String UNKNOWN_IP = "(unknown)";
+    /**
+    * The value to show if the host could not be determined from a URL.
+    */
+    private static final String UNKNOWN_HOST = "(unknown)";
 
     /**
      * {@inheritDoc}
@@ -61,39 +67,8 @@ public class IpReportProvider extends AbstractReportProvider
         {
             final RequestData reqData = (RequestData) data;
             
-            String[] ips = reqData.getIpAddresses();
-            for (int i = 0; i < ips.length; i++)
-            {
-                IpReport ipReport = ipReports.get(ips[i]);
-                if (ipReport == null)
-                {
-                    ipReport = new IpReport();
-                    ipReport.ip = ips[i];
-
-                    ipReports.put(ips[i], ipReport);
-                }
-
-                // update the statistics
-                ipReport.count++;
-            }
-            
-            if (ips.length == 0)
-            {
-                IpReport ipReport = ipReports.get(UNKNOWN_IP);
-                if (ipReport == null)
-                {
-                    ipReport = new IpReport();
-                    ipReport.ip = UNKNOWN_IP;
-
-                    ipReports.put(UNKNOWN_IP, ipReport);
-                }
-
-                // update the statistics
-                ipReport.count++;
-            }
-
             // determine the host name
-            /*String hostName;
+            String hostName;
             final String url = reqData.getUrl();
             if (StringUtils.isBlank(url))
             {
@@ -102,11 +77,46 @@ public class IpReportProvider extends AbstractReportProvider
             else
             {
                 hostName = extractHostNameFromUrl(url);
+            }
+            
+            String[] ips = reqData.getIpAddresses();
+            /*for (int i = 0; i < ips.length; i++)
+            {
+                updateIpCount(ips[i], hostName);
             }*/
+            
+            if (ips.length == 0)
+            {
+                updateIpCount(UNKNOWN_IP, hostName);
+            }
+            else
+            {
+                updateIpCount(ips[0], hostName);
+                // if there are several, just pick the first one for now
+                // (which is wrong, but we don't have the correct data yet)
+            }
+
+            
         }
     }
+    
+    private void updateIpCount(String ip, String host)
+    {
+        IpReport ipReport = ipReports.get(ip+host);
+        if (ipReport == null)
+        {
+            ipReport = new IpReport();
+            ipReport.ip = ip;
+            ipReport.host = host;
 
-    /*private String extractHostNameFromUrl(final String url)
+            ipReports.put(ip+host, ipReport);
+        }
+
+        // update the statistics
+        ipReport.count++;
+    }
+
+    private String extractHostNameFromUrl(final String url)
     {
         String tmp = url;
 
@@ -125,5 +135,5 @@ public class IpReportProvider extends AbstractReportProvider
         }
 
         return tmp;
-    }*/
+    }
 }

--- a/src/main/java/com/xceptance/xlt/report/providers/IpReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/IpReportProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2005-2023 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.report.providers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.xceptance.xlt.api.engine.Data;
+import com.xceptance.xlt.api.engine.RequestData;
+import com.xceptance.xlt.api.report.AbstractReportProvider;
+
+/**
+ * Provides basic statistics for the IP addresses visited during the test.
+ */
+public class IpReportProvider extends AbstractReportProvider
+{
+    /**
+     * A mapping from host names to their corresponding {@link IpReport} objects.
+     */
+    private final Map<String, IpReport> ipReports = new HashMap<String, IpReport>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object createReportFragment()
+    {
+        final IpsReport report = new IpsReport();
+
+        report.ips = new ArrayList<IpReport>(ipReports.values());
+
+        return report;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void processDataRecord(final Data data)
+    {
+        if (data instanceof RequestData)
+        {
+            final RequestData reqData = (RequestData) data;
+            
+            String[] ips = reqData.getIpAddresses();
+            for (int i = 0; i < ips.length; i++)
+            {
+                IpReport ipReport = ipReports.get(ips[i]);
+                if (ipReport == null)
+                {
+                    ipReport = new IpReport();
+                    ipReport.ip = ips[i];
+
+                    ipReports.put(ips[i], ipReport);
+                }
+
+                // update the statistics
+                ipReport.count++;
+            }
+
+            // determine the host name
+            /*String hostName;
+            final String url = reqData.getUrl();
+            if (StringUtils.isBlank(url))
+            {
+                hostName = UNKNOWN_HOST;
+            }
+            else
+            {
+                hostName = extractHostNameFromUrl(url);
+            }*/
+        }
+    }
+
+    /*private String extractHostNameFromUrl(final String url)
+    {
+        String tmp = url;
+
+        // strip protocol if present
+        final int startIndex = tmp.indexOf("://");
+        if (startIndex != -1)
+        {
+            tmp = StringUtils.substring(tmp, startIndex + 3);
+        }
+
+        // strip path/query/fragment if present (whatever comes first)
+        final int endIndex = StringUtils.indexOfAny(tmp, "/?#");
+        if (endIndex != -1)
+        {
+            tmp = StringUtils.substring(tmp, 0, endIndex);
+        }
+
+        return tmp;
+    }*/
+}

--- a/src/main/java/com/xceptance/xlt/report/providers/IpReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/IpReportProvider.java
@@ -32,6 +32,11 @@ public class IpReportProvider extends AbstractReportProvider
      * A mapping from host names to their corresponding {@link IpReport} objects.
      */
     private final Map<String, IpReport> ipReports = new HashMap<String, IpReport>();
+    
+    /**
+     * The value to show if the IP list for the request was empty.
+     */
+    private static final String UNKNOWN_IP = "(unknown)";
 
     /**
      * {@inheritDoc}
@@ -66,6 +71,21 @@ public class IpReportProvider extends AbstractReportProvider
                     ipReport.ip = ips[i];
 
                     ipReports.put(ips[i], ipReport);
+                }
+
+                // update the statistics
+                ipReport.count++;
+            }
+            
+            if (ips.length == 0)
+            {
+                IpReport ipReport = ipReports.get(UNKNOWN_IP);
+                if (ipReport == null)
+                {
+                    ipReport = new IpReport();
+                    ipReport.ip = UNKNOWN_IP;
+
+                    ipReports.put(UNKNOWN_IP, ipReport);
                 }
 
                 // update the statistics

--- a/src/main/java/com/xceptance/xlt/report/providers/IpsReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/IpsReport.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2005-2023 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.report.providers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Represents the IPs section in the test report XML.
+ */
+@XStreamAlias("ips")
+public class IpsReport
+{
+    @XStreamImplicit
+    public List<IpReport> ips = new ArrayList<IpReport>();
+}


### PR DESCRIPTION
We're actually reporting the first IP recorded for each request, which makes only very limited sense (not necessarily the one that has been used in the end?). Would need better input data for IPs that were used (most request data uses cached connections, i.e. has no IP data at all).