### PR TITLE
GH#351: Remove or replace JS stuff in Ant build scripts

### DIFF
--- a/ant-scripts/test.xml
+++ b/ant-scripts/test.xml
@@ -70,7 +70,7 @@
         <resolver:pom id="xlt.pom" file="pom.xml" />
 
         <resolver:dependencies id="depsFromPom" pomRef="xlt.pom" />
-        
+
         <resolver:resolve dependenciesref="depsFromPom" remotereposref="resolver.repositories.test">
             <files refid="test.fileset" scopes="test" />
         </resolver:resolve>
@@ -301,6 +301,14 @@
 
         <junit forkmode="once" fork="yes" printsummary="on">
             <sysproperty key="net.sourceforge.cobertura.datafile" value="${basedir}/cobertura.ser" />
+            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/java.net=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/java.text=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/java.util=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/java.util.regex=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/java.io=ALL-UNNAMED" />
+            <jvmarg value="--add-opens=java.base/sun.nio.fs=ALL-UNNAMED" />
 
             <!-- set classpath -->
             <classpath refid="junit.classpath" />

--- a/ant-scripts/timerrecorder.xml
+++ b/ant-scripts/timerrecorder.xml
@@ -2,29 +2,12 @@
 
 <project name="XLT-TimerRecorder" basedir="..">
 
-    <!-- The XLT version number -->
-    <script language="javascript">
-        <![CDATA[
-               version = project.getProperty("version");
-               versionNumber = "0.0.0";
-               if(version) {
-                 versionNumber = version.match("^(\\d+\\.?)+")[0];
-               } else {
-                 project.setProperty("version", "Custom Build");
-               }
-               project.setProperty("version.number",versionNumber);
-           ]]>
-    </script>
-
     <!-- Read in build properties file. -->
     <property file="build.properties" />
 
     <!-- Set basic build directories. -->
     <property name="build.tools.dir" value="${build.dir}/tools" />
     <property name="target.dir" value="${build.tools.dir}/${timerrecorder.dir}" />
-
-    <!-- Set target directory availability. -->
-    <available property="target.dir.available" file="${target.dir}" type="dir" />
 
     <!-- Set XPI file name. -->
     <property name="xpi.destination" value="${classes.dir}/com/xceptance/xlt/clientperformance" />
@@ -33,11 +16,16 @@
 
     <!-- *** Target definitions *** -->
 
+    <!-- Set target directory availability. -->
+    <target name="check.target-dir" unless="target.dir.available">
+      <available property="target.dir.available" file="${target.dir}" type="dir" />
+    </target>
+
     <!-- Timerrecorder build. -->
     <target name="timerrecorder.build" depends="timerrecorder.xpi" description="Builds the Timer-Recorder extension." />
 
     <!-- Build initialization. -->
-    <target name="timerrecorder.init" unless="target.dir.available">
+    <target name="timerrecorder.init" depends="check.target-dir" unless="target.dir.available">
         <mkdir dir="${target.dir}" />
     </target>
 

--- a/ant-scripts/timerrecorder_chrome.xml
+++ b/ant-scripts/timerrecorder_chrome.xml
@@ -2,29 +2,12 @@
 
 <project name="XLT-TimerRecorder-Chrome" basedir="..">
 
-    <!-- The XLT version number -->
-    <script language="javascript">
-        <![CDATA[
-            version = project.getProperty("version");
-            versionNumber = "0.0.0";
-            if(version) {
-              versionNumber = version.match("^(\\d+\\.?)+")[0];
-            } else {
-              project.setProperty("version", "Custom Build");
-            }
-            project.setProperty("version.number",versionNumber);
-        ]]>
-    </script>
-
     <!-- Read in build properties file. -->
     <property file="build.properties" />
 
     <!-- Set basic build directories. -->
     <property name="build.tools.dir" value="${build.dir}/tools" />
     <property name="target.dir" value="${build.tools.dir}/${timerrecorder.chrome.dir}" />
-
-    <!-- Set target directory availability. -->
-    <available property="target.dir.available" file="${target.dir}" type="dir" />
 
     <!-- Set CRX file properties. -->
     <property name="crx.destination" value="${classes.dir}/com/xceptance/xlt/clientperformance" />
@@ -33,11 +16,16 @@
 
     <!-- *** Target definitions *** -->
 
+    <!-- Set target directory availability. -->
+    <target name="check.target-dir" unless="target.dir.available">
+      <available property="target.dir.available" file="${target.dir}" type="dir" />
+    </target>
+
     <!-- Timerrecorder build. -->
     <target name="timerrecorder.build" depends="timerrecorder.crx" description="Builds the Timer-Recorder extension." />
 
     <!-- Build initialization. -->
-    <target name="timerrecorder.init" unless="target.dir.available">
+    <target name="timerrecorder.init" depends="check.target-dir" unless="target.dir.available">
         <mkdir dir="${target.dir}" />
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -29,18 +29,22 @@
 
     <property name="settings.file" value="/home/hudson/.ant/settings.xml" />
 
-    <scriptdef name="substring" language="javascript">
+    <macrodef name="prefix">
         <attribute name="text" />
-        <attribute name="start" />
-        <attribute name="end" />
+        <attribute name="length" />
         <attribute name="property" />
-        <![CDATA[
-           var text = attributes.get("text");
-           var start = attributes.get("start");
-           var end = Math.min(attributes.get("end") || text.length(), text.length());
-           project.setProperty(attributes.get("property"), text.substring(start, end));
-         ]]>
-    </scriptdef>
+
+        <sequential>
+            <loadresource property="@{property}">
+                <string value="@{text}" />
+                <filterchain>
+                    <tokenfilter>
+                        <replaceregex pattern="^(.{@{length}}).*" replace="\1" />
+                    </tokenfilter>
+                </filterchain>
+            </loadresource>
+        </sequential>
+    </macrodef>
 
     <target name="init.mvn" unless="init.mvn.run">
         <path id="maven-resolver-ant-tasks.classpath" path="${lib-build.dir}/maven-resolver-ant-tasks-1.4.0-uber.jar" />
@@ -62,6 +66,16 @@
         <property name="bin.dist.name" value="${project.name}-${version}" />
         <property name="jar.name" value="${project.name}-${version}.jar" />
         <property name="sourcejar.name" value="${project.name}-${version}-sources.jar" />
+
+        <!-- Determine version number -->
+        <loadresource property="version.number">
+            <propertyresource name="version" />
+            <filterchain>
+                <tokenfilter>
+                  <replaceregex pattern="^(\d+([.]\d+)*).*" replace="\1" flags="gi" />
+                </tokenfilter>
+            </filterchain>
+        </loadresource>
 
         <!-- Name for the generated API documentation file without the file extension -->
         <property name="api.doc.file.name" value="${project.name}-${version}-javadoc" />
@@ -106,8 +120,6 @@
                 <include name="*.jar" />
             </fileset>
         </path>
-
-        <taskdef resource="net/sf/antcontrib/antlib.xml" description="Task definitions for AntContrib." classpathref="classpath" />
 
         <property name="init.run" value="true" />
 
@@ -213,7 +225,7 @@
             <isset property="env.GIT_COMMIT" />
         </condition>
 
-        <substring text="${revision}" end="10" start="0" property="rev.head" />
+        <prefix text="${revision}" length="10" property="rev.head" />
 
         <manifest file="${manifest.file}" mode="update">
             <attribute name="Implementation-Version" value="${version}" />
@@ -311,8 +323,6 @@
             <fileset dir="${lib.dir}" includes="*.jar" />
             <fileset file="${build.dir}/${jar.name}" />
         </copy>
-
-        <propertyregex property="xlt.jenkins.plugin.version" regexp="xlt-jenkins-plugin-([\d\.]+(\-.+)?)\.hpi$" select="\1" input="${xlt-jenkins.hpi.url}" />
 
         <zip zipfile="${build.doc.dir}/${api.doc.file.name}.zip">
             <zipfileset dir="${build.doc.dir}">
@@ -422,11 +432,19 @@
     <!-- Downloads the EC2 on-demand instance information as JS file from AWS. -->
     <target name="download.ec2.instance-info" description="Downloads the EC2 on-demand instance information from AWS.">
         <property file="${basedir}/config/ec2_admin.properties" />
-        <script language="javascript">
-            <![CDATA[
-          project.setProperty('instance.info.url', 'https://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js?callback=callback&_=' + new Date().getTime());
-        ]]>
-        </script>
+
+        <tstamp>
+          <format property="ec2.tstamp" pattern="yyyyMMddHHmmssSSS" />
+        </tstamp>
+        <loadresource property="instance.info.url">
+            <string value="https://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js?callback=callback&amp;_=@TIMESTAMP@" />
+            <filterchain>
+                <replacetokens>
+                    <token key="TIMESTAMP" value="${ec2.tstamp}" />
+                </replacetokens>
+            </filterchain>
+        </loadresource>
+
         <get src="${instance.info.url}" dest="${classes.dir}/com/xceptance/xlt/ec2/linux-od.min.js" usetimestamp="yes" />
         <loadfile property="instance.info.json" srcfile="${classes.dir}/com/xceptance/xlt/ec2/linux-od.min.js" encoding="UTF-8">
             <filterchain>
@@ -528,6 +546,7 @@
         <ant antfile="${timerrecorder.build.file}" target="timerrecorder.build" inheritall="false" inheritrefs="false">
             <propertyset>
                 <propertyref name="version" />
+                <propertyref name="version.number" />
             </propertyset>
         </ant>
     </target>
@@ -537,6 +556,7 @@
             <propertyset>
                 <propertyref name="build.release" />
                 <propertyref name="version" />
+                <propertyref name="version.number" />
             </propertyset>
         </ant>
     </target>
@@ -548,8 +568,7 @@
     -->
 
     <target name="build.resultbrowser" depends="init">
-        <ant antfile="${resultbrowser.build.file}" target="resultbrowser.build" inheritall="false" inheritrefs="false">
-        </ant>
+        <ant antfile="${resultbrowser.build.file}" target="resultbrowser.build" inheritall="false" inheritrefs="false" />
     </target>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -454,18 +454,6 @@
 
         <!-- Ant -->
         <dependency>
-            <groupId>ant-contrib</groupId>
-            <artifactId>ant-contrib</artifactId>
-            <version>1.0b3</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ant</groupId>
-                    <artifactId>ant</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <version>1.10.13</version>


### PR DESCRIPTION
Changes:
- drop build dependency 'ant-contrib'
- remove or replace usages of 'script' and 'scriptdef' tasks
- added required arguments to forked JVM when running tests in order to workaround JPMS issues

Solves #351