### PR TITLE
361 chart sizing

### DIFF
--- a/config/xsl/common/sections/head.xsl
+++ b/config/xsl/common/sections/head.xsl
@@ -5,6 +5,8 @@
 
         <xsl:param name="projectName" />
         <xsl:param name="title" />
+        <xsl:param name="chartWidth" />
+        <xsl:param name="chartHeight" />
 
         <meta charset="utf-8" />
         <!-- Min width set because we cannot handle our data size on a smartphone display -->
@@ -39,6 +41,13 @@
 
         <link rel="icon" href="images/favicon.png" sizes="any" />
         <link rel="icon" href="images/favicon.svg" type="image/svg+xml" />
+        
+        <style type="text/css">
+        	.chart-group img {
+        		width: <xsl:value-of select="$chartWidth" />px;
+        		height: <xsl:value-of select="$chartHeight" />px;
+        	}
+        </style>
 
     </xsl:template>
 

--- a/config/xsl/common/sections/head.xsl
+++ b/config/xsl/common/sections/head.xsl
@@ -44,8 +44,8 @@
         
         <style type="text/css">
         	.chart-group img {
-        		width: <xsl:value-of select="$chartWidth" />px;
-        		height: <xsl:value-of select="$chartHeight" />px;
+        		width: <xsl:value-of select="configuration/chartWidth" />px;
+        		height: <xsl:value-of select="configuration/chartHeight" />px;
         	}
         </style>
 

--- a/config/xsl/common/sections/head.xsl
+++ b/config/xsl/common/sections/head.xsl
@@ -5,8 +5,7 @@
 
         <xsl:param name="projectName" />
         <xsl:param name="title" />
-        <xsl:param name="chartWidth" />
-        <xsl:param name="chartHeight" />
+        <xsl:param name="type" />
 
         <meta charset="utf-8" />
         <!-- Min width set because we cannot handle our data size on a smartphone display -->
@@ -44,8 +43,15 @@
         
         <style type="text/css">
         	.chart-group img {
-        		width: <xsl:value-of select="configuration/chartWidth" />px;
-        		height: <xsl:value-of select="configuration/chartHeight" />px;
+				width: <xsl:value-of select="configuration/chartWidth" />px;
+        	<xsl:choose>				
+                <xsl:when test="$type = 'transactions'">				
+				height: <xsl:value-of select="configuration/chartHeight * 1.5" />px;
+                </xsl:when>
+                <xsl:otherwise>
+				height: <xsl:value-of select="configuration/chartHeight" />px;
+                </xsl:otherwise>
+            </xsl:choose>
         	}
         </style>
 

--- a/config/xsl/loadreport/index.xsl
+++ b/config/xsl/loadreport/index.xsl
@@ -45,8 +45,6 @@
     <xsl:call-template name="head">
         <xsl:with-param name="title" select="'XLT Report - Overview'"/>
         <xsl:with-param name="projectName" select="configuration/projectName" />
-        <xsl:with-param name="chartWidth" select="configuration/chartWidth" />
-        <xsl:with-param name="chartHeight" select="configuration/chartHeight" />
     </xsl:call-template>
 </head>
 <body id="loadtestreport">

--- a/config/xsl/loadreport/index.xsl
+++ b/config/xsl/loadreport/index.xsl
@@ -45,6 +45,8 @@
     <xsl:call-template name="head">
         <xsl:with-param name="title" select="'XLT Report - Overview'"/>
         <xsl:with-param name="projectName" select="configuration/projectName" />
+        <xsl:with-param name="chartWidth" select="configuration/chartWidth" />
+        <xsl:with-param name="chartHeight" select="configuration/chartHeight" />
     </xsl:call-template>
 </head>
 <body id="loadtestreport">

--- a/config/xsl/loadreport/transactions.xsl
+++ b/config/xsl/loadreport/transactions.xsl
@@ -44,6 +44,7 @@
     <xsl:call-template name="head">
         <xsl:with-param name="title" select="'XLT Report - Transactions'" />
         <xsl:with-param name="projectName" select="configuration/projectName" />
+        <xsl:with-param name="type" select="'transactions'"/>
     </xsl:call-template>
 </head>
 <body id="loadtestreport">

--- a/src/main/java/com/xceptance/xlt/report/providers/ConfigurationReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ConfigurationReport.java
@@ -58,4 +58,14 @@ public class ConfigurationReport
      * The name of the (test) project.
      */
     public String projectName;
+
+    /**
+     * The target height for charts.
+     */
+    public int chartHeight;
+
+    /**
+     * The target width for charts.
+     */
+    public int chartWidth;
 }

--- a/src/main/java/com/xceptance/xlt/report/providers/ConfigurationReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ConfigurationReportProvider.java
@@ -131,6 +131,9 @@ public class ConfigurationReportProvider extends AbstractReportProvider
         {
             System.err.println("Failed to get custom JVM arguments. Cause: " + ioe.getMessage());
         }
+        
+        report.chartHeight = getConfiguration().getChartHeight();
+        report.chartWidth = getConfiguration().getChartWidth();
 
         return report;
     }


### PR DESCRIPTION
Right now the trick is done by a css snippet in the page header - should we change this to html width/height attributes on chart images?