### PR TITLE
375 dont filter out overview charts

### DIFF
--- a/config/testreport/js/xlt.js
+++ b/config/testreport/js/xlt.js
@@ -397,7 +397,7 @@
         });
 
         // now filter the charts
-        $('.charts .chart-group.no-print').each(function() {
+        $('.charts:not(.overview) .chart-group.no-print').each(function() {
             var value = this.getAttribute('data-name');
             var visible = filterFunc(value);
 

--- a/config/xsl/loadreport/sections/agents.xsl
+++ b/config/xsl/loadreport/sections/agents.xsl
@@ -10,7 +10,7 @@
             <div class="content">
                 <xsl:call-template name="description-agents"/>
 
-                <div class="charts">
+                <div class="charts overview">
                     <xsl:call-template name="agent-chart">
                         <xsl:with-param name="directory" select="'All Agents'" />
                         <xsl:with-param name="isSummary" select="'true'" />

--- a/config/xsl/loadreport/util/timer-section.xsl
+++ b/config/xsl/loadreport/util/timer-section.xsl
@@ -8,7 +8,7 @@
         <xsl:param name="runtimeIntervalsNode"/>
         <xsl:param name="type"/>
         
-        <div class="charts">
+        <div class="charts overview">
             <xsl:for-each select="$summaryElement">
                 <!-- There is only one matching node. -->
                 <xsl:call-template name="timer-chart">


### PR DESCRIPTION
Added "overview" class to the overview sections before the tables on all relevant pages and made the filter ignore all sections with this class.