### PR TITLE
GH #149: When killing an agent kill the whole process tree

### DIFF
--- a/src/main/java/com/xceptance/xlt/agentcontroller/AgentImpl.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/AgentImpl.java
@@ -239,6 +239,9 @@ public class AgentImpl implements Agent
             // if the agent process monitor is not dead yet, kill the agent process
             if (monitor.isAlive())
             {
+                // terminate all descendant processes first
+                process.descendants().forEach(ProcessHandle::destroyForcibly);
+                // now terminate the agent process itself
                 process.destroyForcibly();
             }
         }


### PR DESCRIPTION
Terminate all descendant processes first before terminating the agent process itself (descends would get a new parent otherwise).

Closes #149