### PR TITLE
295 limit the number of error traces per error type to 10 by default and sample the selection better

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -31,7 +31,7 @@ resultbrowser.dir.source = resultbrowser/dist
 resultbrowser.dir.target = ${classes.dir}/com/xceptance/xlt/engine/resultbrowser/assets
 
 # Linux
-timerrecorder.chrome.executable = chromium-browser
+timerrecorder.chrome.executable = chromium
 # Windows
 #timerrecorder.chrome.executable = C:/Program Files (x86)/Google/Chrome/Application/chrome.exe
 # macOS

--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -54,6 +54,9 @@ com.xceptance.xlt.reportgenerator.requests.removeIndexes = true
 #com.xceptance.xlt.reportgenerator.errors.transactionErrorOverviewChartsLimit = 50
 #com.xceptance.xlt.reportgenerator.errors.transactionErrorDetailChartsLimit = 50
 
+## The maximum number of error traces displayed for each listed error (10 by default).
+#com.xceptance.xlt.reportgenerator.errors.errorTraceCountPerError = 10
+
 ## Width and height of the generated charts (in pixels).
 com.xceptance.xlt.reportgenerator.charts.width = 900
 com.xceptance.xlt.reportgenerator.charts.height = 300

--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -57,6 +57,9 @@ com.xceptance.xlt.reportgenerator.requests.removeIndexes = true
 ## The maximum number of error traces displayed for each listed error (10 by default).
 #com.xceptance.xlt.reportgenerator.errors.errorTraceCountPerError = 10
 
+## The chance to replace error traces when the maximum number of displayed errors is reached (10.0 % by default).
+#com.xceptance.xlt.reportgenerator.errors.errorTraceReplacementChance = 10.0
+
 ## Width and height of the generated charts (in pixels).
 com.xceptance.xlt.reportgenerator.charts.width = 900
 com.xceptance.xlt.reportgenerator.charts.height = 300

--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -54,11 +54,16 @@ com.xceptance.xlt.reportgenerator.requests.removeIndexes = true
 #com.xceptance.xlt.reportgenerator.errors.transactionErrorOverviewChartsLimit = 50
 #com.xceptance.xlt.reportgenerator.errors.transactionErrorDetailChartsLimit = 50
 
-## The maximum number of error traces displayed for each listed error (10 by default).
-#com.xceptance.xlt.reportgenerator.errors.errorTraceCountPerError = 10
+## The maximum number of result browser directories displayed for each listed
+## error (10 by default).
+#com.xceptance.xlt.reportgenerator.errors.directoryLimitPerError = 10
 
-## The chance to replace error traces when the maximum number of displayed errors is reached (10.0 % by default).
-#com.xceptance.xlt.reportgenerator.errors.errorTraceReplacementChance = 10.0
+## The chance to replace directories when the maximum number of directories is
+## reached ([0..1], default: 0.1, i.e. 10%).
+## This ensures that directories processed earlier might also be replaced with
+## directories processed later, resulting in a better sampling of directories
+## across both agents and load test duration in the report.
+#com.xceptance.xlt.reportgenerator.errors.directoryReplacementChance = 0.1
 
 ## Width and height of the generated charts (in pixels).
 com.xceptance.xlt.reportgenerator.charts.width = 900

--- a/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
+++ b/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
@@ -34,6 +34,8 @@ public class XltPropertyNames
             public static final String TRANSACTION_ERROR_DETAIL_CHARTS_LIMIT = BASE + "transactionErrorDetailChartsLimit";
             
             public static final String ERROR_TRACE_COUNT_PER_ERROR = BASE + "errorTraceCountPerError";
+            
+            public static final String ERROR_TRACE_REPLACEMENT_CHANCE = BASE + "errorTraceReplacementChance";
         }
     }
 }

--- a/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
+++ b/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
@@ -33,9 +33,9 @@ public class XltPropertyNames
 
             public static final String TRANSACTION_ERROR_DETAIL_CHARTS_LIMIT = BASE + "transactionErrorDetailChartsLimit";
             
-            public static final String ERROR_TRACE_COUNT_PER_ERROR = BASE + "errorTraceCountPerError";
+            public static final String DIRECTORY_LIMIT_PER_ERROR = BASE + "directoryLimitPerError";
             
-            public static final String ERROR_TRACE_REPLACEMENT_CHANCE = BASE + "errorTraceReplacementChance";
+            public static final String DIRECTORY_REPLACEMENT_CHANCE = BASE + "directoryReplacementChance";
         }
     }
 }

--- a/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
+++ b/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
@@ -32,6 +32,8 @@ public class XltPropertyNames
             public static final String TRANSACTION_ERROR_OVERVIEW_CHARTS_LIMIT = BASE + "transactionErrorOverviewChartsLimit";
 
             public static final String TRANSACTION_ERROR_DETAIL_CHARTS_LIMIT = BASE + "transactionErrorDetailChartsLimit";
+            
+            public static final String ERROR_TRACE_COUNT_PER_ERROR = BASE + "errorTraceCountPerError";
         }
     }
 }

--- a/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
@@ -278,6 +278,8 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     private final int transactionErrorOverviewChartLimit;
 
     private final int errorDetailsChartLimit;
+    
+    private final int errorTraceCountPerError;
 
     private final Map<Pattern, Double> apdexThresholdsByActionNamePattern = new HashMap<>();
 
@@ -402,6 +404,8 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
                                                             50);
         errorDetailsChartLimit = getIntProperty(XltPropertyNames.ReportGenerator.Errors.TRANSACTION_ERROR_DETAIL_CHARTS_LIMIT, 50);
 
+        errorTraceCountPerError = getIntProperty(XltPropertyNames.ReportGenerator.Errors.ERROR_TRACE_COUNT_PER_ERROR, 10);
+        
         // event settings
         groupEventsByTestCase = getBooleanProperty(PROP_PREFIX + "events.groupByTestCase", true);
         eventLimit = getIntProperty(PROP_PREFIX + "events.eventLimit", 100);
@@ -789,6 +793,16 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     public int getErrorDetailsChartLimit()
     {
         return errorDetailsChartLimit;
+    }
+    
+    /**
+     * The maximum number of directory hints remembered for a certain error (stack trace).
+     *
+     * @return the maximum number of error traces to list
+     */
+    public int getErrorTraceCountPerError()
+    {
+        return errorTraceCountPerError;
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
@@ -280,6 +280,8 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     private final int errorDetailsChartLimit;
     
     private final int errorTraceCountPerError;
+    
+    private final double errorTraceReplacementChance;
 
     private final Map<Pattern, Double> apdexThresholdsByActionNamePattern = new HashMap<>();
 
@@ -405,6 +407,9 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
         errorDetailsChartLimit = getIntProperty(XltPropertyNames.ReportGenerator.Errors.TRANSACTION_ERROR_DETAIL_CHARTS_LIMIT, 50);
 
         errorTraceCountPerError = getIntProperty(XltPropertyNames.ReportGenerator.Errors.ERROR_TRACE_COUNT_PER_ERROR, 10);
+        
+        // convert the properties percentage value to a number between 0.0 and 1.0
+        errorTraceReplacementChance = (getDoubleProperty(XltPropertyNames.ReportGenerator.Errors.ERROR_TRACE_REPLACEMENT_CHANCE, 10.0) / 100.0);
         
         // event settings
         groupEventsByTestCase = getBooleanProperty(PROP_PREFIX + "events.groupByTestCase", true);
@@ -803,6 +808,16 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     public int getErrorTraceCountPerError()
     {
         return errorTraceCountPerError;
+    }
+    
+    /**
+     * The chance to replace directory hints remembered for a certain error (stack trace) when the maximum number is reached.
+     *
+     * @return the chance to replace listed error traces
+     */
+    public double getErrorTraceReplacementChance()
+    {
+        return errorTraceReplacementChance;
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
@@ -279,9 +279,9 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
 
     private final int errorDetailsChartLimit;
     
-    private final int errorTraceCountPerError;
+    private final int directoryLimitPerError;
     
-    private final double errorTraceReplacementChance;
+    private final double directoryReplacementChance;
 
     private final Map<Pattern, Double> apdexThresholdsByActionNamePattern = new HashMap<>();
 
@@ -406,10 +406,8 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
                                                             50);
         errorDetailsChartLimit = getIntProperty(XltPropertyNames.ReportGenerator.Errors.TRANSACTION_ERROR_DETAIL_CHARTS_LIMIT, 50);
 
-        errorTraceCountPerError = getIntProperty(XltPropertyNames.ReportGenerator.Errors.ERROR_TRACE_COUNT_PER_ERROR, 10);
-        
-        // convert the properties percentage value to a number between 0.0 and 1.0
-        errorTraceReplacementChance = (getDoubleProperty(XltPropertyNames.ReportGenerator.Errors.ERROR_TRACE_REPLACEMENT_CHANCE, 10.0) / 100.0);
+        directoryLimitPerError = getIntProperty(XltPropertyNames.ReportGenerator.Errors.DIRECTORY_LIMIT_PER_ERROR, 10);
+        directoryReplacementChance = getDoubleProperty(XltPropertyNames.ReportGenerator.Errors.DIRECTORY_REPLACEMENT_CHANCE, 0.1);
         
         // event settings
         groupEventsByTestCase = getBooleanProperty(PROP_PREFIX + "events.groupByTestCase", true);
@@ -805,9 +803,9 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
      *
      * @return the maximum number of error traces to list
      */
-    public int getErrorTraceCountPerError()
+    public int getDirectoryLimitPerError()
     {
-        return errorTraceCountPerError;
+        return directoryLimitPerError;
     }
     
     /**
@@ -815,9 +813,9 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
      *
      * @return the chance to replace listed error traces
      */
-    public double getErrorTraceReplacementChance()
+    public double getDirectoryReplacementChance()
     {
-        return errorTraceReplacementChance;
+        return directoryReplacementChance;
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -86,7 +86,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
     /**
      * The maximum number of directory hints remembered for a certain error (stack trace).
      */
-    private static final int MAXIMUM_NUMBER_OF_HINTS = 25;
+    private final int MAXIMUM_NUMBER_OF_HINTS = getConfiguration().getErrorTraceCountPerError();
 
     /**
      * The dump mode used during the load test.

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -489,8 +489,27 @@ public class ErrorsReportProvider extends AbstractReportProvider
                                                              config.getResultsDirectory().getName().getPath());
                             }
                         }
-                        else if (size == MAXIMUM_NUMBER_OF_HINTS)
+                        else if (size >= MAXIMUM_NUMBER_OF_HINTS)
                         {
+                         // replace hints with a predefined chance
+                            if(random.nextDoubleFast() <= HINT_REPLACEMENT_CHANCE)
+                            {
+                                final ReportGeneratorConfiguration config = (ReportGeneratorConfiguration) getConfiguration();
+                                try
+                                {
+                                    // Check if such a directory is existing.
+                                    if (VFS.getManager().resolveFile(config.getResultsDirectory(), directoryHint).exists())
+                                    {
+                                        // randomly replace one of the existing hints with the new hint
+                                        errorReport.directoryHints.set(random.nextInt(MAXIMUM_NUMBER_OF_HINTS), directoryHint);
+                                    }
+                                }
+                                catch (FileSystemException e)
+                                {
+                                    XltLogger.reportLogger.warn("Unable to parse " + directoryHint + " in " +
+                                                                 config.getResultsDirectory().getName().getPath());
+                                }
+                            }
                         }
                     }
                 }

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -43,6 +43,7 @@ import com.xceptance.xlt.api.engine.RequestData;
 import com.xceptance.xlt.api.engine.TimerData;
 import com.xceptance.xlt.api.engine.TransactionData;
 import com.xceptance.xlt.api.report.AbstractReportProvider;
+import com.xceptance.xlt.api.report.ReportProviderConfiguration;
 import com.xceptance.xlt.api.util.XltLogger;
 import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.engine.resultbrowser.RequestHistory;
@@ -59,31 +60,22 @@ import it.unimi.dsi.util.FastRandom;
  */
 public class ErrorsReportProvider extends AbstractReportProvider
 {
-    private static final String ELLIPSES = "...";
+    /**
+     * The maximum number of directory hints remembered for a certain error (stack trace).
+     */
+    private int directoryLimitPerError;
 
     /**
-     * Compares two directory hints like strings with the exception that an {@link ErrorsReportProvider#ELLIPSES} string
-     * is always lexicographically greater (and thus will end up at the end of the list when sorting multiple directory
-     * hints).
+     * The chance to replace directory hints remembered for a certain error (stack trace) with new hints when above the
+     * maximum number. Given and used in range from 0.0 to 1.0. Converted automatically from the relating property value
+     * which is given in percent.
      */
-    private static final class DirectoryHintComparator implements Comparator<String>
-    {
-        @Override
-        public int compare(String s1, String s2)
-        {
-            if (ELLIPSES.equals(s1))
-            {
-                return 1; // by definition, s1 is greater
-            }
+    private double directoryReplacementChance;
 
-            if (ELLIPSES.equals(s2))
-            {
-                return -1; // by definition, s1 is less
-            }
-
-            return s1.compareTo(s2);
-        }
-    }
+    /**
+     * The root directory of the result set.
+     */
+    private FileObject resultsDirectory;
 
     /**
      * The dump mode used during the load test.
@@ -119,8 +111,8 @@ public class ErrorsReportProvider extends AbstractReportProvider
      * The value sets for each response error code.
      */
     private final Map<String, ValueSet> requestErrorOverviewValues = new HashMap<>();
-    
-    /** 
+
+    /**
      * some fix random sequence that is fast and always the same, this might change in the future
      */
     private final FastRandom random = new FastRandom(98765111L);
@@ -138,10 +130,24 @@ public class ErrorsReportProvider extends AbstractReportProvider
      * {@inheritDoc}
      */
     @Override
+    public void setConfiguration(final ReportProviderConfiguration config)
+    {
+        super.setConfiguration(config);
+
+        // cache some configuration values
+        directoryLimitPerError = getConfiguration().getDirectoryLimitPerError();
+        directoryReplacementChance = getConfiguration().getDirectoryReplacementChance();
+        resultsDirectory = getConfiguration().getResultsDirectory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Object createReportFragment()
     {
-        List<TransactionOverviewChartReport> availableTransactionErrorOverviewCharts = new ArrayList<>();
-        List<RequestErrorChartReport> availableRequestErrorCharts = new ArrayList<>();
+        final List<TransactionOverviewChartReport> availableTransactionErrorOverviewCharts = new ArrayList<>();
+        final List<RequestErrorChartReport> availableRequestErrorCharts = new ArrayList<>();
 
         if (getConfiguration().shouldChartsGenerated())
         {
@@ -172,11 +178,12 @@ public class ErrorsReportProvider extends AbstractReportProvider
             if (getConfiguration().createRequestErrorOverviewCharts())
             {
                 // get top N transaction errors
-                int chartCount = getChartCount(getConfiguration().getRequestErrorOverviewChartLimit(), requestErrorOverviewValues.size());
+                final int chartCount = getChartCount(getConfiguration().getRequestErrorOverviewChartLimit(),
+                                                     requestErrorOverviewValues.size());
                 final List<Entry<String, ValueSet>> selectedErrors = getRequestOverviewErrorsSortedByOccurrence().subList(0, chartCount);
-                for (Entry<String, ValueSet> eachEntry : selectedErrors)
+                for (final Entry<String, ValueSet> eachEntry : selectedErrors)
                 {
-                    RequestErrorChartReport requestErrorChartReport = new RequestErrorChartReport();
+                    final RequestErrorChartReport requestErrorChartReport = new RequestErrorChartReport();
                     requestErrorChartReport.id = Integer.valueOf(eachEntry.getKey());
 
                     availableRequestErrorCharts.add(requestErrorChartReport);
@@ -187,10 +194,10 @@ public class ErrorsReportProvider extends AbstractReportProvider
                     @Override
                     public void run()
                     {
-                        for (Entry<String, ValueSet> eachEntry : selectedErrors)
+                        for (final Entry<String, ValueSet> eachEntry : selectedErrors)
                         {
-                            String responseCode = eachEntry.getKey();
-                            ValueSet data = eachEntry.getValue();
+                            final String responseCode = eachEntry.getKey();
+                            final ValueSet data = eachEntry.getValue();
 
                             createRequestErrorOverviewChart(responseCode, data);
                         }
@@ -202,10 +209,10 @@ public class ErrorsReportProvider extends AbstractReportProvider
             if (getConfiguration().createTransactionErrorOverviewCharts())
             {
                 // get top N transaction errors
-                int chartCount = getChartCount(getConfiguration().getTransactionErrorOverviewChartLimit(),
-                                               transactionErrorOverviewValues.size());
+                final int chartCount = getChartCount(getConfiguration().getTransactionErrorOverviewChartLimit(),
+                                                     transactionErrorOverviewValues.size());
                 final List<TransactionErrorOverviewValues> selectedErrors = getTransactionErrorsSortedByOccurrence().subList(0, chartCount);
-                for (TransactionErrorOverviewValues eachError : selectedErrors)
+                for (final TransactionErrorOverviewValues eachError : selectedErrors)
                 {
                     availableTransactionErrorOverviewCharts.add(eachError.getChartReport());
                 }
@@ -216,7 +223,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
                     @Override
                     public void run()
                     {
-                        for (TransactionErrorOverviewValues eachEntry : selectedErrors)
+                        for (final TransactionErrorOverviewValues eachEntry : selectedErrors)
                         {
                             createTransactionErrorOverviewChart(eachEntry);
                         }
@@ -228,11 +235,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
             if (getConfiguration().createErrorDetailsCharts())
             {
                 // get top N errors
-                int chartCount = getChartCount(getConfiguration().getErrorDetailsChartLimit(), errorReports.size());
+                final int chartCount = getChartCount(getConfiguration().getErrorDetailsChartLimit(), errorReports.size());
                 final List<ErrorValues> selectedErrors = getErrorsSortedByOccurrence().subList(0, chartCount);
 
                 // the selected errors will have a chart and maybe a transaction overview chart, set the ID's
-                for (ErrorValues eachError : selectedErrors)
+                for (final ErrorValues eachError : selectedErrors)
                 {
                     eachError.errorReport.detailChartID = System.identityHashCode(eachError.errorReport);
                 }
@@ -243,7 +250,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
                     @Override
                     public void run()
                     {
-                        for (ErrorValues eachErrorValues : selectedErrors)
+                        for (final ErrorValues eachErrorValues : selectedErrors)
                         {
                             createErrorDetailsChart(eachErrorValues);
                         }
@@ -268,7 +275,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
         return errorReport;
     }
 
-    private int getChartCount(int configuredCount, int collectionSize)
+    private int getChartCount(final int configuredCount, final int collectionSize)
     {
         if (configuredCount < 0 || configuredCount > collectionSize)
         {
@@ -279,11 +286,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
 
     private List<Entry<String, ValueSet>> getRequestOverviewErrorsSortedByOccurrence()
     {
-        ArrayList<Entry<String, ValueSet>> errors = new ArrayList<>(requestErrorOverviewValues.entrySet());
+        final ArrayList<Entry<String, ValueSet>> errors = new ArrayList<>(requestErrorOverviewValues.entrySet());
         Collections.sort(errors, Collections.reverseOrder(new Comparator<Entry<String, ValueSet>>()
         {
             @Override
-            public int compare(Entry<String, ValueSet> o1, Entry<String, ValueSet> o2)
+            public int compare(final Entry<String, ValueSet> o1, final Entry<String, ValueSet> o2)
             {
                 return Long.compare(o1.getValue().getValueCount(), o2.getValue().getValueCount());
             }
@@ -293,11 +300,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
 
     private List<ErrorValues> getErrorsSortedByOccurrence()
     {
-        List<ErrorValues> errors = new ArrayList<ErrorValues>(errorReports.values());
+        final List<ErrorValues> errors = new ArrayList<>(errorReports.values());
         Collections.sort(errors, Collections.reverseOrder(new Comparator<ErrorValues>()
         {
             @Override
-            public int compare(ErrorValues o1, ErrorValues o2)
+            public int compare(final ErrorValues o1, final ErrorValues o2)
             {
                 return Integer.compare(o1.getErrorReport().count, o2.getErrorReport().count);
             }
@@ -307,11 +314,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
 
     private List<TransactionErrorOverviewValues> getTransactionErrorsSortedByOccurrence()
     {
-        List<TransactionErrorOverviewValues> errors = new ArrayList<>(transactionErrorOverviewValues.values());
+        final List<TransactionErrorOverviewValues> errors = new ArrayList<>(transactionErrorOverviewValues.values());
         Collections.sort(errors, Collections.reverseOrder(new Comparator<TransactionErrorOverviewValues>()
         {
             @Override
-            public int compare(TransactionErrorOverviewValues o1, TransactionErrorOverviewValues o2)
+            public int compare(final TransactionErrorOverviewValues o1, final TransactionErrorOverviewValues o2)
             {
                 return Long.compare(o1.getValues().getValueCount(), o2.getValues().getValueCount());
             }
@@ -319,49 +326,50 @@ public class ErrorsReportProvider extends AbstractReportProvider
         return errors;
     }
 
-    private void createRequestErrorOverviewChart(String responseCode, ValueSet data)
+    private void createRequestErrorOverviewChart(final String responseCode, final ValueSet data)
     {
-        String title = "(" + responseCode + ")";
-        String fileName = "r" + responseCode;
+        final String title = "(" + responseCode + ")";
+        final String fileName = "r" + responseCode;
 
-        int width = getConfiguration().getChartWidth();
-        int height = (int) (getConfiguration().getChartHeight() / 2.8);
+        final int width = getConfiguration().getChartWidth();
+        final int height = (int) (getConfiguration().getChartHeight() / 2.8);
 
         createErrorChart(data, fileName, title, "Errors", "Errors", width, height, false, false);
     }
 
-    private void createErrorDetailsChart(ErrorValues errorValues)
+    private void createErrorDetailsChart(final ErrorValues errorValues)
     {
-        ErrorReport errorReport = errorValues.getErrorReport();
+        final ErrorReport errorReport = errorValues.getErrorReport();
 
-        String title = null;
-        String fileName = "d" + errorReport.detailChartID;
-        ValueSet data = errorValues.getValues();
+        final String title = null;
+        final String fileName = "d" + errorReport.detailChartID;
+        final ValueSet data = errorValues.getValues();
 
-        int detailsWidth = (int) (getConfiguration().getChartWidth() / 1.4);
-        int detailsHeight = (int) (getConfiguration().getChartHeight() / 3.5);
+        final int detailsWidth = (int) (getConfiguration().getChartWidth() / 1.4);
+        final int detailsHeight = (int) (getConfiguration().getChartHeight() / 3.5);
 
         createErrorChart(data, fileName, title, null, "Errors", detailsWidth, detailsHeight, false, false);
     }
 
-    private void createTransactionErrorOverviewChart(TransactionErrorOverviewValues errorOverview)
+    private void createTransactionErrorOverviewChart(final TransactionErrorOverviewValues errorOverview)
     {
-        String title = StringUtils.defaultIfBlank(errorOverview.getErrorMessage(), "");
-        String fileName = "t" + errorOverview.getOverviewChartID();
-        ValueSet data = errorOverview.getValues();
+        final String title = StringUtils.defaultIfBlank(errorOverview.getErrorMessage(), "");
+        final String fileName = "t" + errorOverview.getOverviewChartID();
+        final ValueSet data = errorOverview.getValues();
 
-        int overviewWidth = getConfiguration().getChartWidth();
-        int overviewHeight = (int) (getConfiguration().getChartHeight() / 2.8);
+        final int overviewWidth = getConfiguration().getChartWidth();
+        final int overviewHeight = (int) (getConfiguration().getChartHeight() / 2.8);
 
         createErrorChart(data, fileName, title, "Errors", "Errors", overviewWidth, overviewHeight, false, false);
     }
 
-    private void createErrorChart(ValueSet data, String chartName, String chartTitle, String yAxisTitle, String dataName, int width,
-                                  int height, boolean createLegend, boolean createTimeAxis)
+    private void createErrorChart(final ValueSet data, final String chartName, final String chartTitle, final String yAxisTitle,
+                                  final String dataName, final int width, final int height, final boolean createLegend,
+                                  final boolean createTimeAxis)
     {
         final int minMaxValueSetSize = width;
         final TimeSeries eachErrorTimeSeries = JFreeChartUtils.toStandardTimeSeries(data.toMinMaxValueSet(minMaxValueSetSize), dataName);
-        TimeSeriesCollection eachErrorTimeSeriesCollection = new TimeSeriesCollection(eachErrorTimeSeries);
+        final TimeSeriesCollection eachErrorTimeSeriesCollection = new TimeSeriesCollection(eachErrorTimeSeries);
 
         final JFreeChart chart = JFreeChartUtils.createBarChart(chartTitle, eachErrorTimeSeriesCollection, yAxisTitle, Color.RED,
                                                                 getConfiguration().getChartStartTime(),
@@ -372,8 +380,8 @@ public class ErrorsReportProvider extends AbstractReportProvider
 
     private List<ErrorReport> getErrorReports()
     {
-        List<ErrorReport> reports = new ArrayList<>(errorReports.size());
-        for (ErrorValues eachErrorValues : errorReports.values())
+        final List<ErrorReport> reports = new ArrayList<>(errorReports.size());
+        for (final ErrorValues eachErrorValues : errorReports.values())
         {
             reports.add(eachErrorValues.getErrorReport());
         }
@@ -388,11 +396,9 @@ public class ErrorsReportProvider extends AbstractReportProvider
      */
     private void sortDirectoryHints(final ErrorsReport errorsReport)
     {
-        Comparator<String> comparator = new DirectoryHintComparator();
-
-        for (ErrorReport errorReport : errorsReport.errors)
+        for (final ErrorReport errorReport : errorsReport.errors)
         {
-            Collections.sort(errorReport.directoryHints, comparator);
+            Collections.sort(errorReport.directoryHints);
         }
     }
 
@@ -402,18 +408,6 @@ public class ErrorsReportProvider extends AbstractReportProvider
     @Override
     public void processDataRecord(final Data stat)
     {
-        /**
-         * The maximum number of directory hints remembered for a certain error (stack trace).
-         */
-        final int MAXIMUM_NUMBER_OF_HINTS = getConfiguration().getErrorTraceCountPerError();
-        
-        /**
-         * The chance to replace directory hints remembered for a certain error (stack trace)
-         * with new hints when above the maximum number. Given and used in range from 0.0 to 1.0.
-         * Converted automatically from the relating property value which is given in percent.
-         */
-        final double HINT_REPLACEMENT_CHANCE = getConfiguration().getErrorTraceReplacementChance();
-        
         // process error messages/stack traces
         if (stat instanceof TransactionData)
         {
@@ -421,8 +415,6 @@ public class ErrorsReportProvider extends AbstractReportProvider
             final String trace = txnStats.getFailureStackTrace();
             if (trace != null)
             {
-
-
                 // qualify the trace with the test case/action name in case of equal stack traces (#1092)
                 final String testCaseName = txnStats.getName();
                 final String failedActionName = txnStats.getFailedActionName();
@@ -432,7 +424,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
                 ErrorValues errorValues = errorReports.get(key);
                 if (errorValues == null)
                 {
-                    ErrorReport errorReport = new ErrorReport();
+                    final ErrorReport errorReport = new ErrorReport();
                     errorReport.trace = trace;
                     errorReport.message = txnStats.getFailureMessage();
                     errorReport.testCaseName = testCaseName;
@@ -443,7 +435,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
                     errorReports.put(key, errorValues);
                 }
 
-                ErrorReport errorReport = errorValues.getErrorReport();
+                final ErrorReport errorReport = errorValues.getErrorReport();
 
                 // update errors per second for the error details
                 if (getConfiguration().createErrorDetailsCharts())
@@ -454,7 +446,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
                 // update errors per second for the transaction error overview
                 if (getConfiguration().createTransactionErrorOverviewCharts())
                 {
-                    int id = getTransactionErrorOverviewChartID(errorReport.message);
+                    final int id = getTransactionErrorOverviewChartID(errorReport.message);
                     TransactionErrorOverviewValues overviewErrorValues = transactionErrorOverviewValues.get(id);
                     if (overviewErrorValues == null)
                     {
@@ -474,42 +466,40 @@ public class ErrorsReportProvider extends AbstractReportProvider
                     if (directoryHint != null)
                     {
                         final int size = errorReport.directoryHints.size();
-                        if (size < MAXIMUM_NUMBER_OF_HINTS)
+                        if (size < directoryLimitPerError)
                         {
-                            final ReportGeneratorConfiguration config = (ReportGeneratorConfiguration) getConfiguration();
                             try
                             {
                                 // Check if such a directory is existing.
-                                if (VFS.getManager().resolveFile(config.getResultsDirectory(), directoryHint).exists())
+                                if (VFS.getManager().resolveFile(resultsDirectory, directoryHint).exists())
                                 {
                                     errorReport.directoryHints.add(directoryHint);
                                 }
                             }
-                            catch (FileSystemException e)
+                            catch (final FileSystemException e)
                             {
                                 XltLogger.reportLogger.warn("Unable to parse " + directoryHint + " in " +
-                                                             config.getResultsDirectory().getName().getPath());
+                                                            resultsDirectory.getName().getPath());
                             }
                         }
-                        else if (size >= MAXIMUM_NUMBER_OF_HINTS)
+                        else
                         {
-                         // replace hints with a predefined chance
-                            if(random.nextDoubleFast() <= HINT_REPLACEMENT_CHANCE)
+                            // replace hints with a predefined chance
+                            if (random.nextDoubleFast() <= directoryReplacementChance)
                             {
-                                final ReportGeneratorConfiguration config = (ReportGeneratorConfiguration) getConfiguration();
                                 try
                                 {
                                     // Check if such a directory is existing.
-                                    if (VFS.getManager().resolveFile(config.getResultsDirectory(), directoryHint).exists())
+                                    if (VFS.getManager().resolveFile(resultsDirectory, directoryHint).exists())
                                     {
                                         // randomly replace one of the existing hints with the new hint
-                                        errorReport.directoryHints.set(random.nextInt(MAXIMUM_NUMBER_OF_HINTS), directoryHint);
+                                        errorReport.directoryHints.set(random.nextInt(directoryLimitPerError), directoryHint);
                                     }
                                 }
-                                catch (FileSystemException e)
+                                catch (final FileSystemException e)
                                 {
                                     XltLogger.reportLogger.warn("Unable to parse " + directoryHint + " in " +
-                                                                 config.getResultsDirectory().getName().getPath());
+                                                                resultsDirectory.getName().getPath());
                                 }
                             }
                         }
@@ -554,11 +544,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
             // collect the request errors
             if (getConfiguration().createRequestErrorOverviewCharts() && timerData instanceof RequestData)
             {
-                RequestData requestData = (RequestData) timerData;
-                int code = requestData.getResponseCode();
+                final RequestData requestData = (RequestData) timerData;
+                final int code = requestData.getResponseCode();
                 if (code == 0 || code >= 500)
                 {
-                    String responseCode = String.valueOf(code);
+                    final String responseCode = String.valueOf(code);
                     ValueSet valueSet = requestErrorOverviewValues.get(responseCode);
                     if (valueSet == null)
                     {
@@ -580,7 +570,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
     {
         String pathPrefix = null;
 
-        final ReportGeneratorConfiguration config = (ReportGeneratorConfiguration) getConfiguration();
+        final ReportGeneratorConfiguration config = getConfiguration();
         if (config.isGenerateErrorLinks())
         {
             final URI linkedResultsBaseUri = config.getLinkedResultsBaseUri();
@@ -653,9 +643,9 @@ public class ErrorsReportProvider extends AbstractReportProvider
         // final long start = TimerUtils.getTime();
 
         // convert the time series
-        TimeSeriesCollection transactionErrors = new TimeSeriesCollection(transactionErrorsPerSecondTimeSeries);
-        TimeSeriesCollection actionErrors = new TimeSeriesCollection(actionErrorsPerSecondTimeSeries);
-        TimeSeriesCollection requestErrors = new TimeSeriesCollection(requestErrorsPerSecondTimeSeries);
+        final TimeSeriesCollection transactionErrors = new TimeSeriesCollection(transactionErrorsPerSecondTimeSeries);
+        final TimeSeriesCollection actionErrors = new TimeSeriesCollection(actionErrorsPerSecondTimeSeries);
+        final TimeSeriesCollection requestErrors = new TimeSeriesCollection(requestErrorsPerSecondTimeSeries);
 
         // create a combined plot area and add the separate bar plots to it
         final CombinedDomainXYPlot combinedPlot = JFreeChartUtils.createCombinedPlot(getConfiguration().getChartStartTime(),
@@ -681,7 +671,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
         return (ReportGeneratorConfiguration) super.getConfiguration();
     }
 
-    private int getTransactionErrorOverviewChartID(String errorMessage)
+    private int getTransactionErrorOverviewChartID(final String errorMessage)
     {
         return StringUtils.defaultString(errorMessage).hashCode();
     }
@@ -692,7 +682,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
 
         private final ValueSet values = new ValueSet();
 
-        public ErrorValues(ErrorReport errorReport)
+        public ErrorValues(final ErrorReport errorReport)
         {
             this.errorReport = errorReport;
         }
@@ -714,7 +704,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
 
         private final TransactionOverviewChartReport chartReport = new TransactionOverviewChartReport();
 
-        public TransactionErrorOverviewValues(String errorMessage, int overviewChartID)
+        public TransactionErrorOverviewValues(final String errorMessage, final int overviewChartID)
         {
             chartReport.id = overviewChartID;
             chartReport.title = errorMessage;

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -87,6 +87,13 @@ public class ErrorsReportProvider extends AbstractReportProvider
      * The maximum number of directory hints remembered for a certain error (stack trace).
      */
     private final int MAXIMUM_NUMBER_OF_HINTS = getConfiguration().getErrorTraceCountPerError();
+    
+    /**
+     * The chance to replace directory hints remembered for a certain error (stack trace)
+     * with new hints when above the maximum number. Given and used in range from 0.0 to 1.0.
+     * Converted automatically from the relating property value which is given in percent.
+     */
+    private final double HINT_REPLACEMENT_CHANCE = getConfiguration().getErrorTraceReplacementChance();
 
     /**
      * The dump mode used during the load test.

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -52,6 +52,8 @@ import com.xceptance.xlt.report.util.JFreeChartUtils;
 import com.xceptance.xlt.report.util.TaskManager;
 import com.xceptance.xlt.report.util.ValueSet;
 
+import it.unimi.dsi.util.FastRandom;
+
 /**
  *
  */
@@ -407,6 +409,9 @@ public class ErrorsReportProvider extends AbstractReportProvider
     @Override
     public void processDataRecord(final Data stat)
     {
+        // some fix random sequence that is fast and always the same, this might change in the future
+        final FastRandom random = new FastRandom(98765111L);
+        
         // process error messages/stack traces
         if (stat instanceof TransactionData)
         {

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -86,18 +86,6 @@ public class ErrorsReportProvider extends AbstractReportProvider
     }
 
     /**
-     * The maximum number of directory hints remembered for a certain error (stack trace).
-     */
-    private final int MAXIMUM_NUMBER_OF_HINTS = getConfiguration().getErrorTraceCountPerError();
-    
-    /**
-     * The chance to replace directory hints remembered for a certain error (stack trace)
-     * with new hints when above the maximum number. Given and used in range from 0.0 to 1.0.
-     * Converted automatically from the relating property value which is given in percent.
-     */
-    private final double HINT_REPLACEMENT_CHANCE = getConfiguration().getErrorTraceReplacementChance();
-
-    /**
      * The dump mode used during the load test.
      */
     private final DumpMode dumpMode;
@@ -409,6 +397,18 @@ public class ErrorsReportProvider extends AbstractReportProvider
     @Override
     public void processDataRecord(final Data stat)
     {
+        /**
+         * The maximum number of directory hints remembered for a certain error (stack trace).
+         */
+        final int MAXIMUM_NUMBER_OF_HINTS = getConfiguration().getErrorTraceCountPerError();
+        
+        /**
+         * The chance to replace directory hints remembered for a certain error (stack trace)
+         * with new hints when above the maximum number. Given and used in range from 0.0 to 1.0.
+         * Converted automatically from the relating property value which is given in percent.
+         */
+        final double HINT_REPLACEMENT_CHANCE = getConfiguration().getErrorTraceReplacementChance();
+        
         // some fix random sequence that is fast and always the same, this might change in the future
         final FastRandom random = new FastRandom(98765111L);
         

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -119,6 +119,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
      * The value sets for each response error code.
      */
     private final Map<String, ValueSet> requestErrorOverviewValues = new HashMap<>();
+    
+    /** 
+     * some fix random sequence that is fast and always the same, this might change in the future
+     */
+    private final FastRandom random = new FastRandom(98765111L);
 
     /**
      * Constructor.
@@ -408,9 +413,6 @@ public class ErrorsReportProvider extends AbstractReportProvider
          * Converted automatically from the relating property value which is given in percent.
          */
         final double HINT_REPLACEMENT_CHANCE = getConfiguration().getErrorTraceReplacementChance();
-        
-        // some fix random sequence that is fast and always the same, this might change in the future
-        final FastRandom random = new FastRandom(98765111L);
         
         // process error messages/stack traces
         if (stat instanceof TransactionData)

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -491,7 +491,6 @@ public class ErrorsReportProvider extends AbstractReportProvider
                         }
                         else if (size == MAXIMUM_NUMBER_OF_HINTS)
                         {
-                            errorReport.directoryHints.add(ELLIPSES);
                         }
                     }
                 }


### PR DESCRIPTION
limited the number of error traces and made them randomly replaced by later error traces, made amount and replacement chance into XLT properties