### PR TITLE
#379: Report menu hover marker exceeds menu bar vertically

### DIFF
--- a/config/testreport/css/default.css
+++ b/config/testreport/css/default.css
@@ -380,7 +380,6 @@ template {
     --navigation-dropdown-hover-bg-color: #e0e0e0;
 
     --navigation-line-height: 2;
-    --navigation-height: 25px;
 
     --header-full-height: 70px;
     --header-small-height: 30px;
@@ -434,11 +433,17 @@ body
 }
 
 @media screen and (max-width:1399px) {
+    :root {
+        --navigation-height: 25px;
+    }
     html {
         font-size: 14px;
     }
 }
 @media screen and (min-width:1400px) {
+    :root {
+        --navigation-height: 28px;
+    }
     html {
         font-size: 16px;
     }


### PR DESCRIPTION
On wide screens, the font size increases a bit. Ensure the height of the navigation bar is adjusted accordingly.