### PR TITLE
#400: Implement chunked downloads of results

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -31,7 +31,7 @@ resultbrowser.dir.source = resultbrowser/dist
 resultbrowser.dir.target = ${classes.dir}/com/xceptance/xlt/engine/resultbrowser/assets
 
 # Linux
-timerrecorder.chrome.executable = chromium-browser
+timerrecorder.chrome.executable = chromium
 # Windows
 #timerrecorder.chrome.executable = C:/Program Files (x86)/Google/Chrome/Application/chrome.exe
 # macOS

--- a/config/mastercontroller.properties
+++ b/config/mastercontroller.properties
@@ -63,14 +63,14 @@ com.xceptance.xlt.mastercontroller.password = xceptance
 #com.xceptance.xlt.mastercontroller.maxParallelUploads = -1
 #com.xceptance.xlt.mastercontroller.maxParallelDownloads = -1
 
-## The size of a file chunk (in bytes, defaults to 100 MB) when downloading
-## test result archives from the agent controllers in chunks. The chunked
-## mode will be used automatically unless the agent controller does not
-## support it.
+## The size of a file chunk (in bytes, defaults to 100 MB; minimum value: 1000)
+## when downloading test result archives from the agent controllers in chunks.
+## The chunked mode will be used automatically unless the agent controller does
+## not support it.
 #com.xceptance.xlt.mastercontroller.download.chunkSize = 100000000
 
 ## The maximum number of retries if downloading a file (chunk) from an agent
-## controller failed because of an I/O error (defaults to 1).
+## controller failed because of an I/O error (defaults to 1; minimum value: 0).
 #com.xceptance.xlt.mastercontroller.download.maxRetries = 1
 
 # ==================

--- a/config/mastercontroller.properties
+++ b/config/mastercontroller.properties
@@ -69,10 +69,9 @@ com.xceptance.xlt.mastercontroller.password = xceptance
 ## support it.
 #com.xceptance.xlt.mastercontroller.download.chunkSize = 100000000
 
-## The number of attempts when downloading a file (chunk) from an agent
-## controller (defaults to 2). If greater than 1, downloads will silently be
-## retried in case of I/O errors.
-#com.xceptance.xlt.mastercontroller.download.attempts = 2
+## The maximum number of retries if downloading a file (chunk) from an agent
+## controller failed because of an I/O error (defaults to 1).
+#com.xceptance.xlt.mastercontroller.download.maxRetries = 1
 
 # ==================
 #  Result Storage

--- a/config/mastercontroller.properties
+++ b/config/mastercontroller.properties
@@ -63,6 +63,17 @@ com.xceptance.xlt.mastercontroller.password = xceptance
 #com.xceptance.xlt.mastercontroller.maxParallelUploads = -1
 #com.xceptance.xlt.mastercontroller.maxParallelDownloads = -1
 
+## The size of a file chunk (in bytes, defaults to 100 MB) when downloading
+## test result archives from the agent controllers in chunks. The chunked
+## mode will be used automatically unless the agent controller does not
+## support it.
+#com.xceptance.xlt.mastercontroller.download.chunkSize = 100000000
+
+## The number of attempts when downloading a file (chunk) from an agent
+## controller (defaults to 2). If greater than 1, downloads will silently be
+## retried in case of I/O errors.
+#com.xceptance.xlt.mastercontroller.download.attempts = 2
+
 # ==================
 #  Result Storage
 # ==================

--- a/src/main/java/com/xceptance/common/io/IoActionHandler.java
+++ b/src/main/java/com/xceptance/common/io/IoActionHandler.java
@@ -1,0 +1,73 @@
+package com.xceptance.common.io;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link IoActionHandler} runs an {@link IoAction}, and if that action fails with an {@link IOException} (or a
+ * subclass), repeats the action unless the action eventually succeeds or the maximum number of attempts is reached.
+ */
+public class IoActionHandler
+{
+    /**
+     * Functional interface describing an action that performs I/O and may fail with {@link IOException}.
+     * 
+     * @param <T>
+     *            the type of the result of the action
+     */
+    @FunctionalInterface
+    public interface IoAction<T>
+    {
+        public T run() throws IOException;
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(IoActionHandler.class);
+
+    /**
+     * The current number of attempts left.
+     */
+    private int remainingAttempts;
+
+    /**
+     * Creates a new {@link IoActionHandler} initialized with the given number of attempts.
+     */
+    public IoActionHandler(final int attempts)
+    {
+        this.remainingAttempts = attempts;
+    }
+
+    /**
+     * Runs the passed {@link IoAction} performing retries if needed.
+     * 
+     * @param action
+     *            the action to perform
+     * @return the result of the action upon successful attempt
+     * @throws IOException
+     *             the exception thrown by the underlying action if the maximum number of attempts was reached
+     */
+    public <T> T run(final IoAction<T> action) throws IOException
+    {
+        while (true)
+        {
+            remainingAttempts--;
+
+            try
+            {
+                return action.run();
+            }
+            catch (final IOException e)
+            {
+                if (remainingAttempts <= 0)
+                {
+                    throw e;
+                }
+                else
+                {
+                    log.debug("Retry action because of: {}", e.toString());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/xceptance/common/io/IoActionHandler.java
+++ b/src/main/java/com/xceptance/common/io/IoActionHandler.java
@@ -7,13 +7,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * An {@link IoActionHandler} runs an {@link IoAction}, and if that action fails with an {@link IOException} (or a
- * subclass), repeats the action unless the action eventually succeeds or the maximum number of attempts is reached.
+ * subclass), repeats the action until the action eventually succeeds or the maximum number of retries is reached.
  */
 public class IoActionHandler
 {
     /**
      * Functional interface describing an action that performs I/O and may fail with {@link IOException}.
-     * 
+     *
      * @param <T>
      *            the type of the result of the action
      */
@@ -26,46 +26,50 @@ public class IoActionHandler
     private static final Logger log = LoggerFactory.getLogger(IoActionHandler.class);
 
     /**
-     * The current number of attempts left.
+     * The maximum number of retries.
      */
-    private int remainingAttempts;
+    private final int maxRetries;
 
     /**
-     * Creates a new {@link IoActionHandler} initialized with the given number of attempts.
+     * Creates a new {@link IoActionHandler} initialized with the given number of retries.
+     * 
+     * @param maxRetries
+     *            the maximum number of retries
      */
-    public IoActionHandler(final int attempts)
+    public IoActionHandler(final int maxRetries)
     {
-        this.remainingAttempts = attempts;
+        this.maxRetries = maxRetries;
     }
 
     /**
      * Runs the passed {@link IoAction} performing retries if needed.
-     * 
+     *
      * @param action
      *            the action to perform
      * @return the result of the action upon successful attempt
      * @throws IOException
-     *             the exception thrown by the underlying action if the maximum number of attempts was reached
+     *             the exception thrown by the underlying action if the maximum number of retries was reached
      */
     public <T> T run(final IoAction<T> action) throws IOException
     {
+        int remainingRetries = maxRetries;
+
         while (true)
         {
-            remainingAttempts--;
-
             try
             {
                 return action.run();
             }
             catch (final IOException e)
             {
-                if (remainingAttempts <= 0)
+                if (remainingRetries > 0)
                 {
-                    throw e;
+                    log.debug("Retry action because of: {}", e.toString());
+                    remainingRetries--;
                 }
                 else
                 {
-                    log.debug("Retry action because of: {}", e.toString());
+                    throw e;
                 }
             }
         }

--- a/src/main/java/com/xceptance/xlt/agent/AgentMain.java
+++ b/src/main/java/com/xceptance/xlt/agent/AgentMain.java
@@ -136,7 +136,7 @@ public class AgentMain
         proxyFactory.setUser(agentControllerConfig.getUserName());
         proxyFactory.setPassword(agentControllerConfig.getPassword());
 
-        final AgentControllerProxy agentController = new AgentControllerProxy(null, proxyFactory, new UrlConnectionFactory());
+        final AgentControllerProxy agentController = new AgentControllerProxy(null, proxyFactory, new UrlConnectionFactory(), 100_000_000L, 2);
         agentController.startProxy(url);
 
         // setup the agent info

--- a/src/main/java/com/xceptance/xlt/agent/AgentMain.java
+++ b/src/main/java/com/xceptance/xlt/agent/AgentMain.java
@@ -136,7 +136,7 @@ public class AgentMain
         proxyFactory.setUser(agentControllerConfig.getUserName());
         proxyFactory.setPassword(agentControllerConfig.getPassword());
 
-        final AgentControllerProxy agentController = new AgentControllerProxy(null, proxyFactory, new UrlConnectionFactory(), 100_000_000L, 2);
+        final AgentControllerProxy agentController = new AgentControllerProxy(null, proxyFactory, new UrlConnectionFactory());
         agentController.startProxy(url);
 
         // setup the agent info

--- a/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerProxy.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerProxy.java
@@ -72,12 +72,12 @@ public class AgentControllerProxy extends AgentControllerImpl
     /**
      * The size of a file chunk when downloading a result archive from an agent controller.
      */
-    private long downloadChunkSize;
+    private final long downloadChunkSize;
 
     /**
-     * The number of attempts to download a result file (chunk).
+     * The maximum number of retries in case downloading a result file (chunk) failed because of an I/O error.
      */
-    private int downloadMaxRetries;
+    private final int downloadMaxRetries;
 
     /**
      * Creates a new AgentControllerProxy object.

--- a/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerProxy.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/AgentControllerProxy.java
@@ -60,20 +60,36 @@ public class AgentControllerProxy extends AgentControllerImpl
     private final UrlConnectionFactory urlConnectionFactory;
 
     /**
+     * The size of a file chunk when downloading a result archive from an agent controller.
+     */
+    private long downloadChunkSize;
+
+    /**
+     * The number of attempts to download a result file (chunk).
+     */
+    private int downloadAttempts;
+
+    /**
      * Creates a new AgentControllerProxy object.
      *
      * @param commandLineProperties
      * @param proxyFactory
      * @param urlConnectionFactory
+     * @param downloadChunkSize
+     *            the size of a file chunk
+     * @param downloadAttempts
+     *            the number of download attempts
      */
     public AgentControllerProxy(final Properties commandLineProperties, final HessianProxyFactory proxyFactory,
-                                final UrlConnectionFactory urlConnectionFactory)
+                                final UrlConnectionFactory urlConnectionFactory, final long downloadChunkSize, final int downloadAttempts)
         throws Exception
     {
         super(commandLineProperties);
 
         this.proxyFactory = proxyFactory;
         this.urlConnectionFactory = urlConnectionFactory;
+        this.downloadChunkSize = downloadChunkSize;
+        this.downloadAttempts = downloadAttempts;
     }
 
     /**
@@ -130,8 +146,9 @@ public class AgentControllerProxy extends AgentControllerImpl
     public void startProxy(final URL url) throws MalformedURLException
     {
         log.info("start proxy for " + getName());
+
         // start file manager proxy
-        fileManager = new FileManagerProxy(url, urlConnectionFactory);
+        fileManager = new FileManagerProxy(url, urlConnectionFactory, downloadChunkSize, downloadAttempts);
 
         // start agent controller proxy
         agentController = (AgentController) proxyFactory.create(AgentController.class,

--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerProxy.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerProxy.java
@@ -21,17 +21,24 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLConnection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.xceptance.common.io.IoActionHandler;
+import com.xceptance.common.lang.ParseNumbers;
 import com.xceptance.common.net.UrlConnectionFactory;
+import com.xceptance.xlt.api.util.XltException;
+import com.xceptance.xlt.engine.httprequest.HttpRequestHeaders;
+import com.xceptance.xlt.engine.httprequest.HttpResponseHeaders;
 
 /**
  * The FileManagerProxy class is the client-side implementation of the FileManager interface, i.e. it runs on the master
@@ -39,26 +46,69 @@ import com.xceptance.common.net.UrlConnectionFactory;
  */
 public class FileManagerProxy implements FileManager
 {
+    /**
+     * The result returned when downloading a chunk.
+     */
+    private static class ChunkInfo
+    {
+        /** The total size of the resource that is currently being downloaded. */
+        public final long totalSize;
+
+        /** The size of the current chunk. */
+        public final long chunkSize;
+
+        public ChunkInfo(final long totalSize, final long chunkSize)
+        {
+            super();
+            this.totalSize = totalSize;
+            this.chunkSize = chunkSize;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(FileManagerProxy.class);
+
+    /**
+     * A pattern to validate a Content-Range response header (for example, <code>bytes 1000-1999/12345</code>) and
+     * extract values from it.
+     */
+    private static final Pattern CONTENT_RANGE_PATTERN = Pattern.compile("bytes (\\d+)-(\\d+)/(\\d+)");
 
     private final URL url;
 
     private final UrlConnectionFactory urlConnectionFactory;
 
     /**
+     * The size of a file chunk when downloading a result archive from an agent controller.
+     */
+    private long downloadChunkSize;
+
+    /**
+     * The number of attempts to download a result file (chunk).
+     */
+    private int downloadAttempts;
+
+    /**
      * Creates a new FileManagerProxy object.
-     * 
+     *
      * @param url
      *            the agent controller's URL
      * @param urlConnectionFactory
      *            the URL connection factory to use
+     * @param downloadChunkSize
+     *            the size of a file chunk
+     * @param downloadAttempts
+     *            the number of download attempts
      * @throws MalformedURLException
      *             if the file manager's URL cannot be created
      */
-    public FileManagerProxy(final URL url, final UrlConnectionFactory urlConnectionFactory) throws MalformedURLException
+    public FileManagerProxy(final URL url, final UrlConnectionFactory urlConnectionFactory, final long downloadChunkSize,
+                            final int downloadAttempts)
+        throws MalformedURLException
     {
         this.url = new URL(url + FileManagerServlet.SERVLET_PATH);
         this.urlConnectionFactory = urlConnectionFactory;
+        this.downloadChunkSize = downloadChunkSize;
+        this.downloadAttempts = downloadAttempts;
     }
 
     /**
@@ -75,28 +125,156 @@ public class FileManagerProxy implements FileManager
     @Override
     public void downloadFile(final File localFile, final String remoteFileName) throws IOException
     {
-        InputStream cin = null;
-        OutputStream fout = null;
+        final URL downloadUrl = new URL(url + remoteFileName);
 
-        try
+        log.debug("Downloading file from '{}' to '{}' ...", downloadUrl, localFile);
+
+        // make sure the target directory exists
+        FileUtils.forceMkdir(localFile.getParentFile());
+
+        // download the file content in chunks
+        long bytesRead = 0;
+        long totalBytes = Long.MAX_VALUE;
+
+        do
         {
-            final URL downloadUrl = new URL(url + remoteFileName);
+            final long offset = bytesRead;
+            final long bytes = Math.min(downloadChunkSize, totalBytes - offset);
 
-            log.debug("Downloading file from '" + downloadUrl + "' to '" + localFile + "' ...");
+            final ChunkInfo chunkInfo = new IoActionHandler(downloadAttempts).run(() -> downloadFileChunk(localFile, downloadUrl, offset,
+                                                                                                          bytes));
 
-            // make sure the target directory exists
-            FileUtils.forceMkdir(localFile.getParentFile());
-
-            // download file
-            fout = new FileOutputStream(localFile);
-            final URLConnection conn = urlConnectionFactory.open(downloadUrl);
-            cin = conn.getInputStream();
-            IOUtils.copy(cin, fout);
+            bytesRead += chunkInfo.chunkSize;
+            totalBytes = chunkInfo.totalSize;
         }
-        finally
+        while (bytesRead < totalBytes);
+    }
+
+    /**
+     * Downloads a file chunk from the given URL using a partial GET, falling back to downloading the full file if the
+     * agent controller does not support partial GETs.
+     * 
+     * @param localFile
+     *            the file to download the chunk to
+     * @param downloadUrl
+     *            the URL to download the chunk from
+     * @param offset
+     *            the position in the remote file to start the download from
+     * @param bytes
+     *            the number of bytes to download
+     * @return a {@link ChunkInfo} object containing the download details
+     * @throws IOException
+     *             if anything went wrong
+     */
+    private ChunkInfo downloadFileChunk(final File localFile, final URL downloadUrl, final long offset, final long bytes) throws IOException
+    {
+        final long startPos = offset;
+        final long endPos = offset + bytes - 1;
+
+        // request data with a partial GET
+        final HttpURLConnection conn = (HttpURLConnection) urlConnectionFactory.open(downloadUrl);
+        final String rangeHeaderValue = "bytes=" + startPos + "-" + endPos;
+        conn.setRequestProperty(HttpRequestHeaders.RANGE, rangeHeaderValue);
+
+        // check what type of response we got
+        final int statusCode = conn.getResponseCode();
+        if (statusCode == HttpURLConnection.HTTP_OK)
         {
-            IOUtils.closeQuietly(fout);
-            IOUtils.closeQuietly(cin);
+            /*
+             * Response with the full content.
+             */
+
+            log.debug("Downloading complete file from '{}' ...", downloadUrl);
+
+            final long bytesCopied = copyBytes(conn, localFile, false);
+
+            return new ChunkInfo(bytesCopied, bytesCopied);
+        }
+        else if (statusCode == HttpURLConnection.HTTP_PARTIAL)
+        {
+            /*
+             * Response with only a part of the content.
+             */
+
+            log.debug("Downloading chunk {}-{} from '{}' ...", startPos, endPos, downloadUrl);
+
+            // validate Content-Range response header value and extract the total size of the file
+            final String contentRangeHeaderValue = conn.getHeaderField(HttpResponseHeaders.CONTENT_RANGE);
+            final Matcher matcher = CONTENT_RANGE_PATTERN.matcher(contentRangeHeaderValue);
+            if (!matcher.matches())
+            {
+                throw new XltException("Received invalid Content-Range header: " + contentRangeHeaderValue);
+            }
+
+            final long totalBytes = ParseNumbers.parseLong(matcher.group(3));
+
+            // truncate the file to undo any previous attempt to append the current chunk
+            truncateFile(localFile, offset);
+
+            final long bytesCopied = copyBytes(conn, localFile, true);
+
+            return new ChunkInfo(totalBytes, bytesCopied);
+        }
+        else
+        {
+            /*
+             * Unexpected response.
+             */
+
+            throw new XltException("Received unexpected status code: " + statusCode);
+        }
+    }
+
+    /**
+     * Truncates the given file at a certain position.
+     * 
+     * @param file
+     *            the file to truncate
+     * @param newLength
+     *            the position at which to truncate the file
+     * @throws IOException
+     *             if anything went wrong
+     */
+    private void truncateFile(final File file, final long newLength) throws IOException
+    {
+        if (file.length() > newLength)
+        {
+            try (RandomAccessFile raf = new RandomAccessFile(file, "rw"))
+            {
+                raf.setLength(newLength);
+            }
+        }
+    }
+
+    /**
+     * Copies all available data from the URL connection to the file, either appending the data to the file or
+     * overwriting it.
+     * 
+     * @param conn
+     *            the URL connection to read from
+     * @param file
+     *            the file to write to
+     * @param append
+     *            whether to append the data to the file or overwrite it
+     * @return the number of bytes copied
+     * @throws IOException
+     *             if anything went wrong
+     */
+    private long copyBytes(final HttpURLConnection conn, final File file, final boolean append) throws IOException
+    {
+        try (final InputStream cin = conn.getInputStream(); final FileOutputStream fout = new FileOutputStream(file, append))
+        {
+            // copy what is available
+            final long bytesCopied = IOUtils.copyLarge(cin, fout);
+
+            // check whether we copied the expected number of bytes
+            final long bytesAnnounced = conn.getContentLengthLong(); // -1 if not set
+            if (bytesAnnounced != -1 && bytesAnnounced != bytesCopied)
+            {
+                throw new IOException(String.format("Expected %d bytes to copy but got %d bytes", bytesAnnounced, bytesCopied));
+            }
+
+            return bytesCopied;
         }
     }
 

--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerProxy.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerProxy.java
@@ -165,7 +165,7 @@ public class FileManagerProxy implements FileManager
 
         // request data with a partial GET
         final HttpURLConnection conn = (HttpURLConnection) urlConnectionFactory.open(downloadUrl);
-        final String rangeHeaderValue = "bytes=" + startPos + "-" + endPos;
+        final String rangeHeaderValue = PartialGetUtils.formatRangeHeader(startPos, endPos);
         conn.setRequestProperty(HttpRequestHeaders.RANGE, rangeHeaderValue);
 
         // check what type of response we got

--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerProxy.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerProxy.java
@@ -124,6 +124,9 @@ public class FileManagerProxy implements FileManager
         // make sure the target directory exists
         FileUtils.forceMkdir(localFile.getParentFile());
 
+        // prepare retry handling in case of I/O errors
+        final IoActionHandler ioActionHandler = new IoActionHandler(downloadMaxRetries);
+
         // download the file content in chunks
         long bytesRead = 0;
         long totalBytes = Long.MAX_VALUE;
@@ -133,8 +136,7 @@ public class FileManagerProxy implements FileManager
             final long offset = bytesRead;
             final long bytes = Math.min(downloadChunkSize, totalBytes - offset);
 
-            final ChunkInfo chunkInfo = new IoActionHandler(downloadMaxRetries).run(() -> downloadFileChunk(localFile, downloadUrl, offset,
-                                                                                                          bytes));
+            final ChunkInfo chunkInfo = ioActionHandler.run(() -> downloadFileChunk(localFile, downloadUrl, offset, bytes));
 
             bytesRead += chunkInfo.chunkSize;
             totalBytes = chunkInfo.totalSize;

--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
@@ -21,6 +21,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -31,9 +33,13 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.xceptance.common.lang.ParseNumbers;
+import com.xceptance.xlt.engine.httprequest.HttpRequestHeaders;
+import com.xceptance.xlt.engine.httprequest.HttpResponseHeaders;
+
 /**
  * The FileManagerServlet handles all file requests made from the master controller.
- * 
+ *
  * @author Jörg Werner (Xceptance Software Technologies GmbH)
  */
 public class FileManagerServlet extends HttpServlet
@@ -59,13 +65,19 @@ public class FileManagerServlet extends HttpServlet
     static final String SERVLET_MAPPING = SERVLET_PATH + "*";
 
     /**
+     * A pattern to validate a Range request header (for example, <code>bytes=1000-1999</code>) and extract values from
+     * it.
+     */
+    private static final Pattern RANGE_PATTERN = Pattern.compile("bytes=(\\d+)-(\\d+)");
+
+    /**
      * web root directory
      */
     private final File rootDirectory;
 
     /**
      * Creates a new FileManagerServlet object.
-     * 
+     *
      * @param rootDirectory
      *            the local directory that is the web root
      */
@@ -76,7 +88,7 @@ public class FileManagerServlet extends HttpServlet
 
     /**
      * Handles all download requests.
-     * 
+     *
      * @param req
      *            the servlet request
      * @param resp
@@ -92,21 +104,86 @@ public class FileManagerServlet extends HttpServlet
         {
             log.debug("File being downloaded: " + fileName);
 
+            // paranoia check
             if (fileName == null)
             {
-                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+
+            final File file = new File(rootDirectory, fileName);
+
+            // check if the file is empty
+            final long fileLength = file.length();
+            if (fileLength == 0)
+            {
+                // handle empty file
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.setContentLengthLong(0);
+                return;
+            }
+
+            // open the file for reading
+            in = new FileInputStream(file);
+
+            // check for a partial GET request
+            final String rangeHeaderValue = req.getHeader(HttpRequestHeaders.RANGE);
+            if (rangeHeaderValue == null)
+            {
+                /*
+                 * No partial request -> serve the full file content in one go.
+                 */
+
+                log.debug("Serving full content from file '{}' ...", file);
+
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.setContentLengthLong(fileLength);
+
+                final OutputStream out = resp.getOutputStream();
+
+                IOUtils.copyLarge(in, out);
             }
             else
             {
-                final File file = new File(rootDirectory, fileName);
-                in = new FileInputStream(file);
+                /*
+                 * Partial request -> serve only the requested part of the file.
+                 */
 
-                resp.setStatus(HttpServletResponse.SC_OK);
-                resp.setContentLengthLong(file.length());
-                
+                // validate the Range request header
+                final Matcher matcher = RANGE_PATTERN.matcher(rangeHeaderValue);
+                if (!matcher.matches())
+                {
+                    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    return;
+                }
+
+                // extract and validate the start/end position passed in the Range header
+                final long startPos = ParseNumbers.parseLong(matcher.group(1));
+                final long endPos = ParseNumbers.parseLong(matcher.group(2));
+
+                if (startPos > endPos || startPos > fileLength - 1)
+                {
+                    resp.setStatus(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
+                    return;
+                }
+
+                // determine how many bytes can be served at all
+                final long finalEndPos = Math.min(endPos, fileLength - 1);
+                final long bytes = finalEndPos - startPos + 1;
+
+                // prepare the Content-Range response header
+                final String contentRangeHeaderValue = "bytes " + startPos + "-" + finalEndPos + "/" + fileLength;
+
+                // serve the requested byte range
+                log.debug("Serving chunk {}-{} from file '{}' ...", startPos, endPos, file);
+
+                resp.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
+                resp.setContentLengthLong(bytes);
+                resp.setHeader(HttpResponseHeaders.CONTENT_RANGE, contentRangeHeaderValue);
+
                 final OutputStream out = resp.getOutputStream();
 
-                IOUtils.copy(in, out);
+                IOUtils.copyLarge(in, out, startPos, bytes);
             }
         }
         catch (final Exception ex)
@@ -122,7 +199,7 @@ public class FileManagerServlet extends HttpServlet
 
     /**
      * Handles all upload requests.
-     * 
+     *
      * @param req
      *            the servlet request
      * @param resp
@@ -167,7 +244,7 @@ public class FileManagerServlet extends HttpServlet
 
     /**
      * Returns the file name from the URL parameters.
-     * 
+     *
      * @param req
      *            the servlet request
      * @return the file name, or null if not found

--- a/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/FileManagerServlet.java
@@ -172,7 +172,7 @@ public class FileManagerServlet extends HttpServlet
                 final long bytes = finalEndPos - startPos + 1;
 
                 // prepare the Content-Range response header
-                final String contentRangeHeaderValue = "bytes " + startPos + "-" + finalEndPos + "/" + fileLength;
+                final String contentRangeHeaderValue = PartialGetUtils.formatContentRangeHeader(startPos, finalEndPos, fileLength);
 
                 // serve the requested byte range
                 log.debug("Serving chunk {}-{} from file '{}' ...", startPos, endPos, file);

--- a/src/main/java/com/xceptance/xlt/agentcontroller/PartialGetUtils.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/PartialGetUtils.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2005-2023 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.agentcontroller;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.xceptance.common.lang.ParseNumbers;
+
+/**
+ * Helper methods to parse HTTP headers involved when performing partial GET requests.
+ */
+class PartialGetUtils
+{
+    /**
+     * A pattern to validate a Range request header (for example, <code>bytes=1000-1999</code>) and extract values from
+     * it.
+     */
+    private static final Pattern RANGE_PATTERN = Pattern.compile("bytes=(\\d+)-(\\d+)");
+
+    /**
+     * A pattern to validate a Content-Range response header (for example, <code>bytes 1000-1999/12345</code>) and
+     * extract values from it.
+     */
+    private static final Pattern CONTENT_RANGE_PATTERN = Pattern.compile("bytes (\\d+)-(\\d+)/(\\d+)");
+
+    /**
+     * The values passed in a Range request header value.
+     */
+    static class RangeHeaderData
+    {
+        /** The start position of the requested part. **/
+        public final long startPos;
+
+        /** The end position (inclusive) of the requested part. **/
+        public final long endPos;
+
+        public RangeHeaderData(final long startPos, final long endPos)
+        {
+            this.startPos = startPos;
+            this.endPos = endPos;
+        }
+    }
+
+    /**
+     * The values passed in a Content-Range response header value.
+     */
+    static class ContentRangeHeaderData
+    {
+        /** The start position of the returned part. */
+        public final long startPos;
+
+        /** The end position (inclusive) of the returned part. */
+        public final long endPos;
+
+        /** The total size of the resource. */
+        public final long totalBytes;
+
+        public ContentRangeHeaderData(final long startPos, final long endPos, final long totalBytes)
+        {
+            this.startPos = startPos;
+            this.endPos = endPos;
+            this.totalBytes = totalBytes;
+        }
+    }
+
+    /**
+     * Parses the given header value as a Range header and returns the extracted data.
+     * 
+     * @param rangeHeaderValue
+     *            the header value to parse
+     * @return the extracted data if the header could be parsed successfully, <code>null</code> otherwise
+     */
+    static RangeHeaderData parseRangeHeader(final String rangeHeaderValue)
+    {
+        if (rangeHeaderValue != null)
+        {
+            final Matcher matcher = RANGE_PATTERN.matcher(rangeHeaderValue);
+            if (matcher.matches())
+            {
+                final long startPos = ParseNumbers.parseLong(matcher.group(1));
+                final long endPos = ParseNumbers.parseLong(matcher.group(2));
+
+                return new RangeHeaderData(startPos, endPos);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parses the given header value as a Content-Range header and returns the extracted data.
+     * 
+     * @param contentRangeHeaderValue
+     *            the header value to parse
+     * @return the extracted data if the header could be parsed successfully, <code>null</code> otherwise
+     */
+    static ContentRangeHeaderData parseContentRangeHeader(final String contentRangeHeaderValue)
+    {
+        if (contentRangeHeaderValue != null)
+        {
+            final Matcher matcher = CONTENT_RANGE_PATTERN.matcher(contentRangeHeaderValue);
+            if (matcher.matches())
+            {
+                final long startPos = ParseNumbers.parseLong(matcher.group(1));
+                final long endPos = ParseNumbers.parseLong(matcher.group(2));
+                final long totalBytes = ParseNumbers.parseLong(matcher.group(3));
+
+                return new ContentRangeHeaderData(startPos, endPos, totalBytes);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/xceptance/xlt/agentcontroller/PartialGetUtils.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/PartialGetUtils.java
@@ -78,8 +78,22 @@ class PartialGetUtils
     }
 
     /**
+     * Formats the given values as a valid Range request header value.
+     *
+     * @param startPos
+     *            the start position of the requested part
+     * @param endPos
+     *            the end position (inclusive) of the requested part
+     * @return the formatted header value
+     */
+    static String formatRangeHeader(final long startPos, final long endPos)
+    {
+        return "bytes=" + startPos + "-" + endPos;
+    }
+
+    /**
      * Parses the given header value as a Range header and returns the extracted data.
-     * 
+     *
      * @param rangeHeaderValue
      *            the header value to parse
      * @return the extracted data if the header could be parsed successfully, <code>null</code> otherwise
@@ -102,8 +116,24 @@ class PartialGetUtils
     }
 
     /**
+     * Formats the given values as a valid Content-Range response header value.
+     *
+     * @param startPos
+     *            the start position of the returned part
+     * @param endPos
+     *            the end position (inclusive) of the returned part
+     * @param totalBytes
+     *            the total size of the resource
+     * @return the formatted header value
+     */
+    static String formatContentRangeHeader(final long startPos, final long endPos, final long totalBytes)
+    {
+        return "bytes " + startPos + "-" + endPos + "/" + totalBytes;
+    }
+
+    /**
      * Parses the given header value as a Content-Range header and returns the extracted data.
-     * 
+     *
      * @param contentRangeHeaderValue
      *            the header value to parse
      * @return the extracted data if the header could be parsed successfully, <code>null</code> otherwise

--- a/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerConfiguration.java
@@ -283,7 +283,7 @@ public class MasterControllerConfiguration extends AbstractConfiguration
         userName = XltConstants.USER_NAME;
         password = getStringProperty(PROP_PASSWORD, null);
 
-        // do we want to keep the timer files compressed for efficency
+        // do we want to keep the timer files compressed for efficiency
         compressedTimerFiles = getBooleanProperty(PROP_COMPRESSED_TIMER_FILES, true);
 
         // download options

--- a/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerConfiguration.java
@@ -102,7 +102,11 @@ public class MasterControllerConfiguration extends AbstractConfiguration
     private static final String PROP_PASSWORD = PROP_PREFIX + "password";
 
     private static final String PROP_COMPRESSED_TIMER_FILES = PROP_PREFIX + "compressedTimerFiles";
-    
+
+    private static final String PROP_DOWNLOAD_CHUNK_SIZE = PROP_PREFIX + "download.chunkSize";
+
+    private static final String PROP_DOWNLOAD_ATTEMPTS = PROP_PREFIX + "download.attempts";
+
     private final List<AgentControllerConnectionInfo> agentControllerConnectionInfos;
 
     private File agentFilesDirectory;
@@ -156,7 +160,11 @@ public class MasterControllerConfiguration extends AbstractConfiguration
     private final boolean isEmbedded;
 
     private final boolean compressedTimerFiles;
-    
+
+    private long downloadChunkSize;
+
+    private int downloadAttempts;
+
     /**
      * Creates a new MasterControllerConfiguration object.
      * 
@@ -168,7 +176,8 @@ public class MasterControllerConfiguration extends AbstractConfiguration
      *             if an I/O error occurs
      */
     public MasterControllerConfiguration(final File overridePropertyFile, final Properties commandLineProperties,
-                                         final boolean isEmbeddedMode) throws IOException
+                                         final boolean isEmbeddedMode)
+        throws IOException
     {
         isEmbedded = isEmbeddedMode;
         homeDirectory = XltExecutionContext.getCurrent().getXltHomeDir();
@@ -272,9 +281,13 @@ public class MasterControllerConfiguration extends AbstractConfiguration
         // user name/password
         userName = XltConstants.USER_NAME;
         password = getStringProperty(PROP_PASSWORD, null);
-        
+
         // do we want to keep the timer files compressed for efficency
         compressedTimerFiles = getBooleanProperty(PROP_COMPRESSED_TIMER_FILES, true);
+
+        // download options
+        downloadChunkSize = getLongProperty(PROP_DOWNLOAD_CHUNK_SIZE, 100_000_000L);
+        downloadAttempts = getIntProperty(PROP_DOWNLOAD_ATTEMPTS, 2);
     }
 
     /**
@@ -638,7 +651,7 @@ public class MasterControllerConfiguration extends AbstractConfiguration
     {
         return isEmbedded;
     }
-    
+
     /**
      * How shall we handle timer files after the download
      * 
@@ -647,5 +660,25 @@ public class MasterControllerConfiguration extends AbstractConfiguration
     public boolean isCompressedTimerFiles()
     {
         return compressedTimerFiles;
+    }
+
+    /**
+     * Returns the size of a file chunk when downloading a result archive from an agent controller.
+     * 
+     * @return the chunk size (in bytes)
+     */
+    public long getDownloadChunkSize()
+    {
+        return downloadChunkSize;
+    }
+
+    /**
+     * Returns the number of attempts to download a result file (chunk).
+     * 
+     * @return the number of attempts
+     */
+    public int getDownloadAttempts()
+    {
+        return downloadAttempts;
     }
 }

--- a/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerMain.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerMain.java
@@ -274,7 +274,9 @@ public class MasterControllerMain
         for (final AgentControllerConnectionInfo info : connectionInfos)
         {
             final int agentCount = info.getNumberOfAgents();
-            final AgentControllerProxy agentController = new AgentControllerProxy(commandLineProps, proxyFactory, urlConnectionFactory);
+            final AgentControllerProxy agentController = new AgentControllerProxy(commandLineProps, proxyFactory, urlConnectionFactory,
+                                                                                  config.getDownloadChunkSize(),
+                                                                                  config.getDownloadAttempts());
 
             try
             {

--- a/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerMain.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerMain.java
@@ -276,7 +276,7 @@ public class MasterControllerMain
             final int agentCount = info.getNumberOfAgents();
             final AgentControllerProxy agentController = new AgentControllerProxy(commandLineProps, proxyFactory, urlConnectionFactory,
                                                                                   config.getDownloadChunkSize(),
-                                                                                  config.getDownloadAttempts());
+                                                                                  config.getDownloadMaxRetries());
 
             try
             {

--- a/src/test/java/com/xceptance/xlt/agentcontroller/PartialGetUtils_ContentRangeHeaderTest.java
+++ b/src/test/java/com/xceptance/xlt/agentcontroller/PartialGetUtils_ContentRangeHeaderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2005-2023 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.agentcontroller;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.xceptance.xlt.agentcontroller.PartialGetUtils.ContentRangeHeaderData;
+
+@RunWith(Parameterized.class)
+public class PartialGetUtils_ContentRangeHeaderTest
+{
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data()
+    {
+        return Arrays.asList(new Object[][]
+            {
+                {
+                    null, null
+                },
+                {
+                    "", null
+                },
+                {
+                    "   ", null
+                },
+                {
+                    "bytes", null
+                },
+                {
+                    "bytes ", null
+                },
+                {
+                    "bytes 0", null
+                },
+                {
+                    "bytes 0-0", null
+                },
+                {
+                    "bytes 0-0/1", new ContentRangeHeaderData(0, 0, 1)
+                },
+                {
+                    "bytes 0-999/12345", new ContentRangeHeaderData(0, 999, 12345)
+                },
+                {
+                    "bytes 1000-1999/12345", new ContentRangeHeaderData(1000, 1999, 12345)
+                }
+            });
+    }
+
+    @Parameter(value = 0)
+    public String headerValue;
+
+    @Parameter(value = 1)
+    public ContentRangeHeaderData expectedHeaderData;
+
+    @Test
+    public void parseContentRangeHeader()
+    {
+        final ContentRangeHeaderData actualHeaderData = PartialGetUtils.parseContentRangeHeader(headerValue);
+
+        if (expectedHeaderData == null)
+        {
+            Assert.assertNull(actualHeaderData);
+        }
+        else
+        {
+            Assert.assertEquals(expectedHeaderData.startPos, actualHeaderData.startPos);
+            Assert.assertEquals(expectedHeaderData.endPos, actualHeaderData.endPos);
+            Assert.assertEquals(expectedHeaderData.totalBytes, actualHeaderData.totalBytes);
+        }
+    }
+}

--- a/src/test/java/com/xceptance/xlt/agentcontroller/PartialGetUtils_RangeHeaderTest.java
+++ b/src/test/java/com/xceptance/xlt/agentcontroller/PartialGetUtils_RangeHeaderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2005-2023 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.agentcontroller;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.xceptance.xlt.agentcontroller.PartialGetUtils.RangeHeaderData;
+
+@RunWith(Parameterized.class)
+public class PartialGetUtils_RangeHeaderTest
+{
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data()
+    {
+        return Arrays.asList(new Object[][]
+            {
+                {
+                    null, null
+                },
+                {
+                    "", null
+                },
+                {
+                    "   ", null
+                },
+                {
+                    "bytes", null
+                },
+                {
+                    "bytes=", null
+                },
+                {
+                    "bytes=0", null
+                },
+                {
+                    "bytes=0-0", new RangeHeaderData(0, 0)
+                },
+                {
+                    "bytes=0-999", new RangeHeaderData(0, 999)
+                },
+                {
+                    "bytes=1000-1999", new RangeHeaderData(1000, 1999)
+                }
+            });
+    }
+
+    @Parameter(value = 0)
+    public String headerValue;
+
+    @Parameter(value = 1)
+    public RangeHeaderData expectedHeaderData;
+
+    @Test
+    public void parseRangeHeader()
+    {
+        final RangeHeaderData actualHeaderData = PartialGetUtils.parseRangeHeader(headerValue);
+
+        if (expectedHeaderData == null)
+        {
+            Assert.assertNull(actualHeaderData);
+        }
+        else
+        {
+            Assert.assertEquals(expectedHeaderData.startPos, actualHeaderData.startPos);
+            Assert.assertEquals(expectedHeaderData.endPos, actualHeaderData.endPos);
+        }
+    }
+}


### PR DESCRIPTION
- Use a series of partial GETs to download an archive file in chunks.
- Fall back to a full download in case the agent controller does not support chunked download yet.
- Retry downloading a file (chunk) in case of I/O errors.
- Made chunk size and download attempts per chunk configurable.
- Changed name of Chromium binary from "chromium-browser" to "chromium".