### PR TITLE
#411: Escape values in DOM nodes only when writing them out

### DIFF
--- a/src/main/java/com/xceptance/common/xml/AbstractDomPrinter.java
+++ b/src/main/java/com/xceptance/common/xml/AbstractDomPrinter.java
@@ -154,7 +154,8 @@ public abstract class AbstractDomPrinter
         {
             final Attr attribute = (Attr) attributes.item(i);
 
-            printWriter.print(" " + attribute.getName() + "=\"" + attribute.getValue() + "\"");
+            printWriter.print(" " + StringEscapeUtils.escapeXml10(attribute.getName()) + "=\"" +
+                              StringEscapeUtils.escapeXml10(attribute.getValue()) + "\"");
         }
     }
 

--- a/src/main/java/com/xceptance/common/xml/DomUtils.java
+++ b/src/main/java/com/xceptance/common/xml/DomUtils.java
@@ -18,7 +18,6 @@ package com.xceptance.common.xml;
 import java.io.OutputStream;
 import java.io.Writer;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
@@ -163,7 +162,7 @@ public final class DomUtils
         for (int i = 0; i < attributes.getLength(); i++)
         {
             final Attr attribute = (Attr) attributes.item(i);
-            clone.setAttribute(attribute.getName(), StringEscapeUtils.escapeXml10(attribute.getValue()));
+            clone.setAttribute(attribute.getName(), attribute.getValue());
         }
 
         // clone the children
@@ -201,7 +200,7 @@ public final class DomUtils
      */
     private static Node cloneText(final Text node, final Document document)
     {
-        return document.createTextNode(StringEscapeUtils.escapeXml10(node.getData()));
+        return document.createTextNode(node.getData());
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/DomUtils.java
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/DomUtils.java
@@ -38,7 +38,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
-import com.google.common.html.HtmlEscapers;
 import com.xceptance.common.util.ParameterCheckUtils;
 
 /**
@@ -299,18 +298,15 @@ final class DomUtils
             final Attr attribute = (Attr) attributes.item(i);
             try
             {
-                // XLT#1954: Attribute values of the clone have to be escaped correctly since the raw value of the
-                // original attribute is not available anymore and their node value is already unescaped.
-                final String value = HtmlEscapers.htmlEscaper().escape(attribute.getValue());
                 // GH#88: Use namespaceURI of attribute and fall back to namespaceURI of owner element node if not set.
-                clone.setAttributeNS(ObjectUtils.defaultIfNull(attribute.getNamespaceURI(), nodeNS), attribute.getName(), value);
+                clone.setAttributeNS(ObjectUtils.defaultIfNull(attribute.getNamespaceURI(), nodeNS), attribute.getName(),
+                                     attribute.getValue());
             }
             catch (final DOMException dex)
             {
                 if (LOG.isWarnEnabled())
                 {
-                    LOG.warn(String.format("Failed to set attribute <%s> to value <%s>", attribute.getName(),
-                                                               attribute.getValue()));
+                    LOG.warn(String.format("Failed to set attribute <%s> to value <%s>", attribute.getName(), attribute.getValue()));
                 }
             }
         }


### PR DESCRIPTION
- Don't escape text nodes and attributes when cloning them.
- Escape name and value of attributes when outputting them. Text nodes are already escaped.