### PR TITLE
423 disable js engine

### DIFF
--- a/samples/testsuite-performance/config/default.properties
+++ b/samples/testsuite-performance/config/default.properties
@@ -182,18 +182,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ################################################################################
 
 ## Whether the JavaScript Engine is enabled. Default is false.
-## The JS engine of the HtmlUnit webclient is heavy, if we don't need
-## it, we don't start it
-# com.xceptance.xlt.javaScriptEngineEnabled = false
+## The JS engine of the HtmlUnit web client is heavy so if you don't need it,
+## don't enable it.
+#com.xceptance.xlt.javaScriptEngineEnabled = false
 
-## Whether JavaScript is enabled AND the JS engine has been started too.
-## Setting this to false still starts the JS engine (if set top true) but does not
-## execute any JS in the page. Default is false.
-# com.xceptance.xlt.javaScriptEnabled = false
+## Whether the execution of JavaScript code in a Web page is enabled. Default
+## is false. When enabling it, ensure the javaScriptEngineEnabled flag above
+## is true as well.
+#com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.
-com.xceptance.xlt.js.debugger.enabled = false
+#com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether
 ## downloaded JavaScript content should be beautified in order to ease debugging.

--- a/samples/testsuite-performance/config/default.properties
+++ b/samples/testsuite-performance/config/default.properties
@@ -181,10 +181,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 #
 ################################################################################
 
-## Whether JavaScript is enabled.
-com.xceptance.xlt.javaScriptEnabled = true
+## Whether the JavaScript Engine is enabled. Default is false.
+## The JS engine of the HtmlUnit webclient is heavy, if we don't need
+## it, we don't start it
+# com.xceptance.xlt.javaScriptEngineEnabled = false
+
+## Whether JavaScript is enabled AND the JS engine has been started too.
+## Setting this to false still starts the JS engine (if set top true) but does not
+## execute any JS in the page. Default is false.
+# com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
+## Default is false.
 com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether

--- a/samples/testsuite-posters/config/default.properties
+++ b/samples/testsuite-posters/config/default.properties
@@ -181,10 +181,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 #
 ################################################################################
 
-## Whether JavaScript is enabled.
-com.xceptance.xlt.javaScriptEnabled = true
+## Whether the JavaScript Engine is enabled. Default is false.
+## The JS engine of the HtmlUnit webclient is heavy, if we don't need
+## it, we don't start it
+# com.xceptance.xlt.javaScriptEngineEnabled = false
+
+## Whether JavaScript is enabled AND the JS engine has been started too.
+## Setting this to false still starts the JS engine (if set top true) but does not
+## execute any JS in the page. Default is false.
+# com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
+## Default is false.
 com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether

--- a/samples/testsuite-posters/config/default.properties
+++ b/samples/testsuite-posters/config/default.properties
@@ -182,18 +182,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ################################################################################
 
 ## Whether the JavaScript Engine is enabled. Default is false.
-## The JS engine of the HtmlUnit webclient is heavy, if we don't need
-## it, we don't start it
+## The JS engine of the HtmlUnit web client is heavy so if you don't need it,
+## don't enable it.
 com.xceptance.xlt.javaScriptEngineEnabled = true
 
-## Whether JavaScript is enabled AND the JS engine has been started too.
-## Setting this to false still starts the JS engine (if set top true) but does not
-## execute any JS in the page. Default is false.
+## Whether the execution of JavaScript code in a Web page is enabled. Default
+## is false. When enabling it, ensure the javaScriptEngineEnabled flag above
+## is true as well.
 com.xceptance.xlt.javaScriptEnabled = true
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.
-com.xceptance.xlt.js.debugger.enabled = false
+#com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether
 ## downloaded JavaScript content should be beautified in order to ease debugging.

--- a/samples/testsuite-posters/config/default.properties
+++ b/samples/testsuite-posters/config/default.properties
@@ -184,12 +184,12 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ## Whether the JavaScript Engine is enabled. Default is false.
 ## The JS engine of the HtmlUnit webclient is heavy, if we don't need
 ## it, we don't start it
-# com.xceptance.xlt.javaScriptEngineEnabled = false
+com.xceptance.xlt.javaScriptEngineEnabled = true
 
 ## Whether JavaScript is enabled AND the JS engine has been started too.
 ## Setting this to false still starts the JS engine (if set top true) but does not
 ## execute any JS in the page. Default is false.
-# com.xceptance.xlt.javaScriptEnabled = false
+com.xceptance.xlt.javaScriptEnabled = true
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.

--- a/samples/testsuite-showcases/config/default.properties
+++ b/samples/testsuite-showcases/config/default.properties
@@ -181,10 +181,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 #
 ################################################################################
 
-## Whether JavaScript is enabled.
-com.xceptance.xlt.javaScriptEnabled = true
+## Whether the JavaScript Engine is enabled. Default is false.
+## The JS engine of the HtmlUnit webclient is heavy, if we don't need
+## it, we don't start it
+# com.xceptance.xlt.javaScriptEngineEnabled = false
+
+## Whether JavaScript is enabled AND the JS engine has been started too.
+## Setting this to false still starts the JS engine (if set top true) but does not
+## execute any JS in the page. Default is false.
+# com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
+## Default is false.
 com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether

--- a/samples/testsuite-showcases/config/default.properties
+++ b/samples/testsuite-showcases/config/default.properties
@@ -182,18 +182,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ################################################################################
 
 ## Whether the JavaScript Engine is enabled. Default is false.
-## The JS engine of the HtmlUnit webclient is heavy, if we don't need
-## it, we don't start it
+## The JS engine of the HtmlUnit web client is heavy so if you don't need it,
+## don't enable it.
 com.xceptance.xlt.javaScriptEngineEnabled = true
 
-## Whether JavaScript is enabled AND the JS engine has been started too.
-## Setting this to false still starts the JS engine (if set top true) but does not
-## execute any JS in the page. Default is false.
+## Whether the execution of JavaScript code in a Web page is enabled. Default
+## is false. When enabling it, ensure the javaScriptEngineEnabled flag above
+## is true as well.
 com.xceptance.xlt.javaScriptEnabled = true
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.
-com.xceptance.xlt.js.debugger.enabled = false
+#com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether
 ## downloaded JavaScript content should be beautified in order to ease debugging.

--- a/samples/testsuite-showcases/config/default.properties
+++ b/samples/testsuite-showcases/config/default.properties
@@ -184,12 +184,12 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ## Whether the JavaScript Engine is enabled. Default is false.
 ## The JS engine of the HtmlUnit webclient is heavy, if we don't need
 ## it, we don't start it
-# com.xceptance.xlt.javaScriptEngineEnabled = false
+com.xceptance.xlt.javaScriptEngineEnabled = true
 
 ## Whether JavaScript is enabled AND the JS engine has been started too.
 ## Setting this to false still starts the JS engine (if set top true) but does not
 ## execute any JS in the page. Default is false.
-# com.xceptance.xlt.javaScriptEnabled = false
+com.xceptance.xlt.javaScriptEnabled = true
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.

--- a/samples/testsuite-template/config/default.properties
+++ b/samples/testsuite-template/config/default.properties
@@ -182,18 +182,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ################################################################################
 
 ## Whether the JavaScript Engine is enabled. Default is false.
-## The JS engine of the HtmlUnit webclient is heavy, if we don't need
-## it, we don't start it
-# com.xceptance.xlt.javaScriptEngineEnabled = false
+## The JS engine of the HtmlUnit web client is heavy so if you don't need it,
+## don't enable it.
+#com.xceptance.xlt.javaScriptEngineEnabled = false
 
-## Whether JavaScript is enabled AND the JS engine has been started too.
-## Setting this to false still starts the JS engine (if set top true) but does not
-## execute any JS in the page. Default is false.
-# com.xceptance.xlt.javaScriptEnabled = false
+## Whether the execution of JavaScript code in a Web page is enabled. Default
+## is false. When enabling it, ensure the javaScriptEngineEnabled flag above
+## is true as well.
+#com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.
-com.xceptance.xlt.js.debugger.enabled = false
+#com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether
 ## downloaded JavaScript content should be beautified in order to ease debugging.

--- a/samples/testsuite-template/config/default.properties
+++ b/samples/testsuite-template/config/default.properties
@@ -181,10 +181,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 #
 ################################################################################
 
-## Whether JavaScript is enabled.
-com.xceptance.xlt.javaScriptEnabled = true
+## Whether the JavaScript Engine is enabled. Default is false.
+## The JS engine of the HtmlUnit webclient is heavy, if we don't need
+## it, we don't start it
+# com.xceptance.xlt.javaScriptEngineEnabled = false
+
+## Whether JavaScript is enabled AND the JS engine has been started too.
+## Setting this to false still starts the JS engine (if set top true) but does not
+## execute any JS in the page. Default is false.
+# com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
+## Default is false
 com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether

--- a/samples/testsuite-template/config/default.properties
+++ b/samples/testsuite-template/config/default.properties
@@ -192,7 +192,7 @@ com.xceptance.xlt.staticContentCache.size = 1000
 # com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
-## Default is false
+## Default is false.
 com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether

--- a/samples/testsuite-xlt/config/default.properties
+++ b/samples/testsuite-xlt/config/default.properties
@@ -181,10 +181,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 #
 ################################################################################
 
-## Whether JavaScript is enabled.
-com.xceptance.xlt.javaScriptEnabled = true
+## Whether the JavaScript Engine is enabled. Default is false.
+## The JS engine of the HtmlUnit webclient is heavy, if we don't need
+## it, we don't start it
+# com.xceptance.xlt.javaScriptEngineEnabled = false
+
+## Whether JavaScript is enabled AND the JS engine has been started too.
+## Setting this to false still starts the JS engine (if set top true) but does not
+## execute any JS in the page. Default is false.
+# com.xceptance.xlt.javaScriptEnabled = false
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
+## Default is false.
 com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether

--- a/samples/testsuite-xlt/config/default.properties
+++ b/samples/testsuite-xlt/config/default.properties
@@ -182,18 +182,18 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ################################################################################
 
 ## Whether the JavaScript Engine is enabled. Default is false.
-## The JS engine of the HtmlUnit webclient is heavy, if we don't need
-## it, we don't start it
+## The JS engine of the HtmlUnit web client is heavy so if you don't need it,
+## don't enable it.
 com.xceptance.xlt.javaScriptEngineEnabled = true
 
-## Whether JavaScript is enabled AND the JS engine has been started too.
-## Setting this to false still starts the JS engine (if set top true) but does not
-## execute any JS in the page. Default is false.
+## Whether the execution of JavaScript code in a Web page is enabled. Default
+## is false. When enabling it, ensure the javaScriptEngineEnabled flag above
+## is true as well.
 com.xceptance.xlt.javaScriptEnabled = true
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.
-com.xceptance.xlt.js.debugger.enabled = false
+#com.xceptance.xlt.js.debugger.enabled = false
 
 ## In case the JavaScript debugger is enabled, this setting controls whether
 ## downloaded JavaScript content should be beautified in order to ease debugging.

--- a/samples/testsuite-xlt/config/default.properties
+++ b/samples/testsuite-xlt/config/default.properties
@@ -184,12 +184,12 @@ com.xceptance.xlt.staticContentCache.size = 1000
 ## Whether the JavaScript Engine is enabled. Default is false.
 ## The JS engine of the HtmlUnit webclient is heavy, if we don't need
 ## it, we don't start it
-# com.xceptance.xlt.javaScriptEngineEnabled = false
+com.xceptance.xlt.javaScriptEngineEnabled = true
 
 ## Whether JavaScript is enabled AND the JS engine has been started too.
 ## Setting this to false still starts the JS engine (if set top true) but does not
 ## execute any JS in the page. Default is false.
-# com.xceptance.xlt.javaScriptEnabled = false
+com.xceptance.xlt.javaScriptEnabled = true
 
 ## Whether the JavaScript debugger (function call logger) is enabled.
 ## Default is false.

--- a/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
+++ b/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
@@ -191,7 +191,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
     /**
      * The JavaScript debugger
      */
-    private final XltDebugger xltDebugger;
+    private XltDebugger xltDebugger;
 
     // Initialize globally valid things.
     // This code assures, that we only do it once and reuse it all the time.
@@ -247,7 +247,21 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     public XltWebClient(final BrowserVersion browserVersion)
     {
-        super(copyAndModifyBrowserVersion(browserVersion));
+        this(null, XltProperties.getInstance().getProperty("com.xceptance.xlt.javaScriptEngineEnabled", false));
+    }
+
+    /**
+     * Creates a new XltWebClient object that emulates the specified browser. All other settings are taken from the XLT
+     * configuration.
+     *
+     * @param browserVersion
+     *            the browser version to use (may be <code>null</code>)
+     * @param fullyDisableJavaScript
+     *              avoids bringing up the JS engine entirely in the first place
+     */
+    public XltWebClient(final BrowserVersion browserVersion, final boolean fullyDisableJavaScript)
+    {
+        super(copyAndModifyBrowserVersion(browserVersion), fullyDisableJavaScript, null, 0);
 
         Session.getCurrent().addShutdownListener(this);
 
@@ -304,7 +318,6 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
         getOptions().setThrowExceptionOnScriptError(props.getProperty("com.xceptance.xlt.stopTestOnJavaScriptErrors", false));
 
         // setup JavaScript debugger
-        xltDebugger = new XltDebugger(this);
         if (props.getProperty("com.xceptance.xlt.js.debugger.enabled", false))
         {
             setJavaScriptDebuggerEnabled(true);
@@ -1755,6 +1768,10 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     public void setJavaScriptDebuggerEnabled(final boolean enabled)
     {
+        if (xltDebugger == null)
+        {
+            xltDebugger = new XltDebugger(this);
+        }
         xltDebugger.setEnabled(enabled);
     }
 
@@ -1765,7 +1782,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     public boolean isJavaScriptDebuggerEnabled()
     {
-        return xltDebugger.isEnabled();
+        return xltDebugger == null ? false : xltDebugger.isEnabled();
     }
 
     private static URL normalizeUrl(final URL url) throws MalformedURLException

--- a/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
+++ b/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
@@ -332,6 +332,10 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
                 }
             }
         }
+        else
+        {
+            getOptions().setJavaScriptEnabled(false);
+        }
 
         // default user authentication
         final String userName = props.getProperty("com.xceptance.xlt.auth.userName");
@@ -656,7 +660,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     public void loadNewStaticContent(final HtmlPage htmlPage)
     {
-        if (loadStaticContent && isJavaScriptEnabled())
+        if (loadStaticContent && isJavaScriptEngineEnabled())
         {
             final URL referrerURL = htmlPage.getWebResponse().getWebRequest().getUrl();
             URL baseURL = referrerURL;

--- a/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
+++ b/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
@@ -768,7 +768,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     private void loadStaticContent(final WebResponse response)
     {
-        final boolean haveJS = getOptions().isJavaScriptEnabled();
+        final boolean haveJS = isJavaScriptEnabled();
         final boolean haveCss = getOptions().isCssEnabled();
 
         // Exit early
@@ -1252,7 +1252,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     public void waitForBackgroundThreads(final Page page, final long maximumWaitingTime)
     {
-        if (getOptions().isJavaScriptEnabled())
+        if (isJavaScriptEnabled())
         {
             if (maximumWaitingTime >= 0)
             {

--- a/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
+++ b/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
@@ -247,7 +247,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      */
     public XltWebClient(final BrowserVersion browserVersion)
     {
-        this(null, XltProperties.getInstance().getProperty("com.xceptance.xlt.javaScriptEngineEnabled", false));
+        this(browserVersion, XltProperties.getInstance().getProperty("com.xceptance.xlt.javaScriptEngineEnabled", false));
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/engine/scripting/htmlunit/ElementFinder.java
+++ b/src/main/java/com/xceptance/xlt/engine/scripting/htmlunit/ElementFinder.java
@@ -287,7 +287,7 @@ public class ElementFinder
         @Override
         protected HtmlElement find(final HtmlPage page, final String domExpression)
         {
-            if (!page.getWebClient().getOptions().isJavaScriptEnabled())
+            if (!page.getWebClient().isJavaScriptEnabled())
             {
                 throw new ScriptException("JavaScript needs to be enabled when using DOM locator strategy");
             }

--- a/src/main/java/com/xceptance/xlt/engine/scripting/htmlunit/HtmlUnitCommandAdapter.java
+++ b/src/main/java/com/xceptance/xlt/engine/scripting/htmlunit/HtmlUnitCommandAdapter.java
@@ -1451,7 +1451,7 @@ public final class HtmlUnitCommandAdapter extends AbstractCommandAdapter impleme
     @Override
     protected String _evaluate(final String expression)
     {
-        if (!getWebClient().getOptions().isJavaScriptEnabled())
+        if (!getWebClient().isJavaScriptEnabled())
         {
             return null;
         }

--- a/src/test/java/com/xceptance/xlt/api/actions/AbstractHtmlPageActionTest.java
+++ b/src/test/java/com/xceptance/xlt/api/actions/AbstractHtmlPageActionTest.java
@@ -22,10 +22,13 @@ import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlSelect;
+import org.junit.After;
 import org.junit.Test;
 
 import com.xceptance.xlt.AbstractXLTTestCase;
 import com.xceptance.xlt.api.util.XltException;
+import com.xceptance.xlt.api.util.XltProperties;
+import com.xceptance.xlt.engine.XltEngine;
 
 /**
  * Test the implementation of {@link AbstractHtmlPageAction}.
@@ -34,6 +37,12 @@ import com.xceptance.xlt.api.util.XltException;
  */
 public class AbstractHtmlPageActionTest extends AbstractXLTTestCase
 {
+    @After
+    public void resetXltEngine()
+    {
+        XltEngine.reset(); // also initializes XLT properties again 
+    }
+
     @Test
     public void testLoadPage() throws Throwable
     {
@@ -260,6 +269,10 @@ public class AbstractHtmlPageActionTest extends AbstractXLTTestCase
     @Test
     public void testLoadPageByTypeKeys() throws Throwable
     {
+        // typing requires JS support
+        final XltProperties props = XltProperties.getInstance();
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+
         final URL test1 = new URL("http://localhost/test1");
         final URL test2 = new URL("http://localhost/test2?name=Bob");
 

--- a/src/test/java/com/xceptance/xlt/engine/BaseUrlHandleTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/BaseUrlHandleTest.java
@@ -18,6 +18,7 @@ package com.xceptance.xlt.engine;
 import java.util.List;
 
 import org.htmlunit.html.HtmlPage;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,7 +37,13 @@ public class BaseUrlHandleTest extends AbstractWebTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.css.download.images", "onDemand");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
-        props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+    }
+
+    @AfterClass
+    public static void reset()
+    {
+        XltEngine.reset();
     }
 
     @Test

--- a/src/test/java/com/xceptance/xlt/engine/XltWebClientLoadStaticContentTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/XltWebClientLoadStaticContentTest.java
@@ -81,6 +81,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "");
         props.setProperty("com.xceptance.xlt.cssEnabled", "");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "");
         props.setProperty("com.xceptance.xlt.css.download.images", "");
     }
@@ -121,6 +122,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
     {
         // set the test specific load parameter
         final XltProperties props = XltProperties.getInstance();
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
@@ -139,6 +141,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
@@ -159,6 +162,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "false");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "false");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "false");
 
         // start an open page action
@@ -179,6 +183,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "false");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "false");
 
         // start an open page action
@@ -199,6 +204,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "false");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
@@ -219,6 +225,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "false");
         props.setProperty("com.xceptance.xlt.cssEnabled", "false");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "false");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "false");
 
         // start an open page action
@@ -236,6 +243,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "false");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
@@ -255,6 +263,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "false");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true"); // JS engine needed for CSS evaluation
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "false");
 
         // start an open page action
@@ -273,6 +282,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "false");
         props.setProperty("com.xceptance.xlt.cssEnabled", "false");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
@@ -356,6 +366,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         props.setProperty("com.xceptance.xlt.loadStaticContent", "false");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
         props.setProperty("com.xceptance.xlt.css.download.images", "always");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
 
         // start an open page action
         startCssLoadsImage();
@@ -378,6 +389,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         final XltProperties props = XltProperties.getInstance();
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
@@ -518,6 +530,8 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
         props.setProperty("com.xceptance.xlt.css.download.images", "ondemand");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
         startDifferentMediaTypes("testWebSites/testWebSiteMediaTypes.html");
@@ -545,6 +559,8 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
         props.setProperty("com.xceptance.xlt.css.download.images", "ondemand");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
         startDifferentMediaTypes("testWebSites/testWebSiteMediaTypesCssSyntax.html");
@@ -572,6 +588,8 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
         props.setProperty("com.xceptance.xlt.css.download.images", "ondemand");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
         startDifferentMediaTypesAndRecursiveCss("@import url(\"print.css\") print; @import \"screen.css\" screen; " +
@@ -599,6 +617,8 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
         props.setProperty("com.xceptance.xlt.css.download.images", "ondemand");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         // start an open page action
         startDifferentMediaTypesAndRecursiveCss("@media screen {#background{background-image: url(\"screen.gif\");}} " +
@@ -719,6 +739,7 @@ public class XltWebClientLoadStaticContentTest extends AbstractXLTTestCase
         props.setProperty("com.xceptance.xlt.loadStaticContent", "true");
         props.setProperty("com.xceptance.xlt.cssEnabled", "true");
         props.setProperty("com.xceptance.xlt.css.download.images", "never");
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
         props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
 
         final String html = "<html><head></head><body><h1>Foo</h1><script>" + "var e = document.createElement('link');" +

--- a/src/test/java/com/xceptance/xlt/engine/scripting/webdriver/WebDriverUtilsTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/scripting/webdriver/WebDriverUtilsTest.java
@@ -20,22 +20,34 @@
 package com.xceptance.xlt.engine.scripting.webdriver;
 
 import org.htmlunit.MockWebConnection;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 
+import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.api.webdriver.XltDriver;
+import com.xceptance.xlt.engine.XltEngine;
 
 /**
  * Tests the implementation of {@link WebDriverUtils}.
  */
 public class WebDriverUtilsTest
 {
-
+    @After
+    public void resetXltEngine()
+    {
+        XltEngine.reset(); // also initializes XLT properties again 
+    }
+    
     private WebDriver getWebDriver(final boolean jsEnabled)
     {
-        final XltDriver driver = new XltDriver(jsEnabled);
+        final XltProperties props = XltProperties.getInstance();
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", String.valueOf(jsEnabled));
+        props.setProperty("com.xceptance.xlt.javaScriptEnabled", String.valueOf(jsEnabled));
+        
+        final XltDriver driver = new XltDriver();
         final MockWebConnection conn = new MockWebConnection();
         conn.setDefaultResponse("<h1>Hello</h1><p>... World!</p>");
         driver.getWebClient().setWebConnection(conn);
@@ -99,6 +111,5 @@ public class WebDriverUtilsTest
             Assert.assertTrue(t.getMessage().startsWith("Failed to evaluate JavaScript"));
             throw t;
         }
-
     }
 }

--- a/src/test/java/com/xceptance/xlt/engine/xltdriver/_2897_ClickOnDisabledElementTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/xltdriver/_2897_ClickOnDisabledElementTest.java
@@ -20,20 +20,32 @@
 package com.xceptance.xlt.engine.xltdriver;
 
 import org.htmlunit.MockWebConnection;
+import org.junit.After;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidElementStateException;
 
+import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.api.webdriver.XltDriver;
+import com.xceptance.xlt.engine.XltEngine;
 
 /**
  * Test for issue 2897 (click on disabled element throws {@link InvalidElementStateException}).
  */
 public class _2897_ClickOnDisabledElementTest
 {
+    @After
+    public void resetXltEngine()
+    {
+        XltEngine.reset(); // also initializes XLT properties again
+    }
+
     @Test(expected = org.openqa.selenium.InvalidElementStateException.class)
     public void ensureInvalidElementStateException() throws Throwable
     {
+        final XltProperties props = XltProperties.getInstance();
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+
         final String html = "<form action='/foo' method='POST'><input type=hidden name=bar value=bum />" +
                             "<button disabled name=submit value=submit id=btn>Click Me</button></form>";
         final XltDriver driver = new XltDriver(false);

--- a/src/test/java/org/htmlunit/_1983_IFrameLoadTest.java
+++ b/src/test/java/org/htmlunit/_1983_IFrameLoadTest.java
@@ -17,11 +17,14 @@ package org.htmlunit;
 
 import java.net.URL;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.xceptance.xlt.api.tests.AbstractTestCase;
+import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.api.webdriver.XltDriver;
+import com.xceptance.xlt.engine.XltEngine;
 import com.xceptance.xlt.engine.XltWebClient;
 
 /**
@@ -29,10 +32,20 @@ import com.xceptance.xlt.engine.XltWebClient;
  */
 public class _1983_IFrameLoadTest extends AbstractTestCase
 {
+    @After
+    public void resetXltEngine()
+    {
+        XltEngine.reset(); // also initializes XLT properties again 
+    }
+
     @Test
     public void test() throws Exception
     {
-        final XltDriver driver = new XltDriver(true);
+        final XltProperties props = XltProperties.getInstance();
+        props.setProperty("com.xceptance.xlt.javaScriptEngineEnabled", "true");
+        props.setProperty("com.xceptance.xlt.javaScriptEnabled", "true");
+        
+        final XltDriver driver = new XltDriver();
         ((XltWebClient) driver.getWebClient()).setLoadStaticContent(true);
 
         final MockWebConnection webConnection = new MockWebConnection();

--- a/src/test/java/org/htmlunit/_2144_FileInputHasNonZeroWidthTest.java
+++ b/src/test/java/org/htmlunit/_2144_FileInputHasNonZeroWidthTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.xceptance.xlt.AbstractWebTestCase;
+import com.xceptance.xlt.engine.XltWebClient;
 
 /**
  * Tests that the bounding box of HTML file inputs have non-zero height and width.
@@ -32,6 +33,11 @@ import com.xceptance.xlt.AbstractWebTestCase;
  */
 public class _2144_FileInputHasNonZeroWidthTest extends AbstractWebTestCase
 {
+    protected XltWebClient createWebClient()
+    {
+        return new XltWebClient(null, true);
+    }
+
     @Test
     public void testNonZeroWidth() throws Throwable
     {


### PR DESCRIPTION
JS engine is off by default and not started. A short test has shown that the scripts for regular load tests still work. We are also not creating the debugger object, if not needed.

## CPU
-10 %

### Old
![image](https://github.com/Xceptance/XLT/assets/1793856/9ec40867-1200-415c-b601-5e2527889a1a)

### New
![image](https://github.com/Xceptance/XLT/assets/1793856/402ab0cb-ca09-487d-990c-2e58da485320)

## Memory
-200 MB

### Old
![image](https://github.com/Xceptance/XLT/assets/1793856/9e3a40d5-c7bf-473b-b7b2-647f53a4ebc9)

### New
![image](https://github.com/Xceptance/XLT/assets/1793856/e107dcab-4fd4-49f6-9dfe-cd13791ff36b)
