### PR TITLE
Upgrade guava from 31.1-jre to 32.1.2-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>32.1.2-jre</version>
         </dependency>
         <!-- Script-Doc Generator -->
         <dependency>


### PR DESCRIPTION
Update Guava to latest available version to fix vulnerabilities when working with temporary files in Guava v31.1-jre.