### PR TITLE
#179: Support for JDK 17+

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/socket/InstrumentedSocketImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/socket/InstrumentedSocketImpl.java
@@ -182,6 +182,15 @@ class InstrumentedSocketImpl extends SocketImpl
     }
 
     /**
+     * Initializes this class for instrumentation.
+     */
+    public static void initialize()
+    {
+        // Calling this method the first time implicitly triggers the static initializer block above to be executed
+        // once. Apart from that, there is nothing more to do here.
+    }
+
+    /**
      * The actual socket implementation.
      */
     private final SocketImpl socketImpl;

--- a/src/main/java/com/xceptance/xlt/engine/socket/InstrumentedSocketImplFactory.java
+++ b/src/main/java/com/xceptance/xlt/engine/socket/InstrumentedSocketImplFactory.java
@@ -25,6 +25,15 @@ import java.net.SocketImplFactory;
 class InstrumentedSocketImplFactory implements SocketImplFactory
 {
     /**
+     * Constructor.
+     */
+    public InstrumentedSocketImplFactory()
+    {
+        // try to initialize and throw if initialization fails
+        InstrumentedSocketImpl.initialize();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/com/xceptance/xlt/engine/socket/XltSockets.java
+++ b/src/main/java/com/xceptance/xlt/engine/socket/XltSockets.java
@@ -15,9 +15,12 @@
  */
 package com.xceptance.xlt.engine.socket;
 
-import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketImplFactory;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.common.XltConstants;
@@ -35,6 +38,8 @@ import com.xceptance.xlt.common.XltConstants;
  */
 public final class XltSockets
 {
+    private static final Logger LOG = LoggerFactory.getLogger(XltSockets.class);
+
     private static final String PROP_COLLECT_NETWORK_DATA = XltConstants.XLT_PACKAGE_PATH + ".socket.collectNetworkData";
 
     static
@@ -46,9 +51,9 @@ public final class XltSockets
                 // set the global socket impl factory
                 Socket.setSocketImplFactory(new InstrumentedSocketImplFactory());
             }
-            catch (final IOException ex)
+            catch (final Throwable ex)
             {
-                throw new RuntimeException("Failed to initialize XLT sockets", ex);
+                LOG.warn("Failed to initialize XLT sockets: {}", ExceptionUtils.getRootCauseMessage(ex));
             }
         }
     }

--- a/src/main/java/com/xceptance/xlt/engine/socket/XltSockets.java
+++ b/src/main/java/com/xceptance/xlt/engine/socket/XltSockets.java
@@ -22,6 +22,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.xceptance.xlt.api.engine.Session;
+import com.xceptance.xlt.api.util.XltException;
 import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.common.XltConstants;
 
@@ -53,7 +55,14 @@ public final class XltSockets
             }
             catch (final Throwable ex)
             {
-                LOG.warn("Failed to initialize XLT sockets: {}", ExceptionUtils.getRootCauseMessage(ex));
+                if (Session.getCurrent().isLoadTest())
+                {
+                    throw new XltException("Failed to initialize XLT sockets", ex);
+                }
+                else
+                {
+                    LOG.warn("Failed to initialize XLT sockets: {}", ExceptionUtils.getRootCauseMessage(ex));
+                }
             }
         }
     }


### PR DESCRIPTION
XLT does no longer throw if the socket layer cannot be instrumented with the used JVM, but logs a warning only.