### PR TITLE
#436: Result Browser: Cannot view request details

### DIFF
--- a/resultbrowser/src/js/json-tree.js
+++ b/resultbrowser/src/js/json-tree.js
@@ -437,7 +437,9 @@
          * @param {(string) => void} handler - consumes the JSON path of the target node
          */
         onJsonNodeSelected(handler) {
-            attachEventHandlers(this.tree, (node) => handler(node.getJsonPath()));
+            if (this.tree) {
+                attachEventHandlers(this.tree, (node) => handler(node.getJsonPath()));
+            }
         }   
     }
 


### PR DESCRIPTION
Attach event handlers only if there is a valid JSON tree.