### PR TITLE
439 stacktrace limiter

### DIFF
--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -65,8 +65,11 @@ com.xceptance.xlt.reportgenerator.requests.removeIndexes = true
 ## across both agents and load test duration in the report.
 #com.xceptance.xlt.reportgenerator.errors.directoryReplacementChance = 0.1
 
-## TO DO meaningful help text
-com.xceptance.xlt.reportgenerator.errors.stackTracesLimit = 2
+## The maximum number of listed errors that stack traces will be displayed for
+## (500 by default).
+## Setting a lower limit may prevent the report generator going out of memory in 
+## case of numerous different errors.
+#com.xceptance.xlt.reportgenerator.errors.stackTracesLimit = 10
 
 ## Width and height of the generated charts (in pixels).
 com.xceptance.xlt.reportgenerator.charts.width = 900

--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -65,11 +65,10 @@ com.xceptance.xlt.reportgenerator.requests.removeIndexes = true
 ## across both agents and load test duration in the report.
 #com.xceptance.xlt.reportgenerator.errors.directoryReplacementChance = 0.1
 
-## The maximum number of listed errors that stack traces will be displayed for
-## (500 by default).
-## Setting a lower limit may prevent the report generator going out of memory in 
-## case of numerous different errors.
-#com.xceptance.xlt.reportgenerator.errors.stackTracesLimit = 10
+## The maximum number of errors for which stack traces will be displayed (500 by
+## default). Setting a lower limit can prevent the report generator from running
+## out of memory if there are many different errors.
+#com.xceptance.xlt.reportgenerator.errors.stackTracesLimit = 500
 
 ## Width and height of the generated charts (in pixels).
 com.xceptance.xlt.reportgenerator.charts.width = 900

--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -65,6 +65,9 @@ com.xceptance.xlt.reportgenerator.requests.removeIndexes = true
 ## across both agents and load test duration in the report.
 #com.xceptance.xlt.reportgenerator.errors.directoryReplacementChance = 0.1
 
+## TO DO meaningful help text
+com.xceptance.xlt.reportgenerator.errors.stackTracesLimit = 2
+
 ## Width and height of the generated charts (in pixels).
 com.xceptance.xlt.reportgenerator.charts.width = 900
 com.xceptance.xlt.reportgenerator.charts.height = 300

--- a/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
+++ b/src/main/java/com/xceptance/xlt/common/XltPropertyNames.java
@@ -36,6 +36,8 @@ public class XltPropertyNames
             public static final String DIRECTORY_LIMIT_PER_ERROR = BASE + "directoryLimitPerError";
             
             public static final String DIRECTORY_REPLACEMENT_CHANCE = BASE + "directoryReplacementChance";
+            
+            public static final String STACKTRACES_LIMIT = BASE + "stackTracesLimit";
         }
     }
 }

--- a/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
@@ -280,6 +280,8 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     private final int directoryLimitPerError;
     
     private final double directoryReplacementChance;
+    
+    private final int stackTracesLimit;
 
     private final Map<Pattern, Double> apdexThresholdsByActionNamePattern = new HashMap<>();
 
@@ -406,6 +408,8 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
 
         directoryLimitPerError = getIntProperty(XltPropertyNames.ReportGenerator.Errors.DIRECTORY_LIMIT_PER_ERROR, 10);
         directoryReplacementChance = getDoubleProperty(XltPropertyNames.ReportGenerator.Errors.DIRECTORY_REPLACEMENT_CHANCE, 0.1);
+        
+        stackTracesLimit = getIntProperty(XltPropertyNames.ReportGenerator.Errors.STACKTRACES_LIMIT, 500);
         
         // event settings
         groupEventsByTestCase = getBooleanProperty(PROP_PREFIX + "events.groupByTestCase", true);
@@ -806,6 +810,16 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     public double getDirectoryReplacementChance()
     {
         return directoryReplacementChance;
+    }
+    
+    /**
+     * The maximum number of directory hints remembered for a certain error (stack trace).
+     *
+     * @return the maximum number of error traces to list
+     */
+    public int getStackTracesLimit()
+    {
+        return stackTracesLimit;
     }
 
     /**

--- a/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
@@ -795,7 +795,7 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     /**
      * The maximum number of directory hints remembered for a certain error (stack trace).
      *
-     * @return the maximum number of error traces to list
+     * @return the maximum number of directories to list
      */
     public int getDirectoryLimitPerError()
     {
@@ -805,7 +805,7 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     /**
      * The chance to replace directory hints remembered for a certain error (stack trace) when the maximum number is reached.
      *
-     * @return the chance to replace listed error traces
+     * @return the chance to replace listed directory hints
      */
     public double getDirectoryReplacementChance()
     {
@@ -813,9 +813,9 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
     }
     
     /**
-     * The maximum number of directory hints remembered for a certain error (stack trace).
+     * The maximum number of errors that will be saved complete with their stack trace.
      *
-     * @return the maximum number of error traces to list
+     * @return the maximum number of error stack traces displayed in the report
      */
     public int getStackTracesLimit()
     {

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -71,6 +71,11 @@ public class ErrorsReportProvider extends AbstractReportProvider
      * which is given in percent.
      */
     private double directoryReplacementChance;
+    
+    /**
+     * The maximum number of directory hints remembered for a certain error (stack trace).
+     */
+    private int stackTracesLimit;
 
     /**
      * The root directory of the result set.
@@ -137,6 +142,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
         // cache some configuration values
         directoryLimitPerError = getConfiguration().getDirectoryLimitPerError();
         directoryReplacementChance = getConfiguration().getDirectoryReplacementChance();
+        stackTracesLimit = getConfiguration().getStackTracesLimit();
         resultsDirectory = getConfiguration().getResultsDirectory();
     }
 
@@ -425,11 +431,13 @@ public class ErrorsReportProvider extends AbstractReportProvider
                 if (errorValues == null)
                 {
                     final ErrorReport errorReport = new ErrorReport();
-                    errorReport.trace = trace;
                     errorReport.message = txnStats.getFailureMessage();
                     errorReport.testCaseName = testCaseName;
                     errorReport.actionName = failedActionName;
                     errorReport.detailChartID = 0;
+                    
+                    //if (stackTracesLimit not reached) //TODO
+                    errorReport.trace = trace;
 
                     errorValues = new ErrorValues(errorReport);
                     errorReports.put(key, errorValues);

--- a/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ErrorsReportProvider.java
@@ -73,7 +73,7 @@ public class ErrorsReportProvider extends AbstractReportProvider
     private double directoryReplacementChance;
     
     /**
-     * The maximum number of directory hints remembered for a certain error (stack trace).
+     * The maximum number of errors that will be saved complete with their stack trace.
      */
     private int stackTracesLimit;
 
@@ -436,8 +436,14 @@ public class ErrorsReportProvider extends AbstractReportProvider
                     errorReport.actionName = failedActionName;
                     errorReport.detailChartID = 0;
                     
-                    //if (stackTracesLimit not reached) //TODO
-                    errorReport.trace = trace;
+                    if (errorReports.size() < stackTracesLimit) //only save stacktraces up to limit
+                    {
+                        errorReport.trace = trace;
+                    }
+                    else
+                    {
+                        errorReport.trace = "n/a";
+                    }
 
                     errorValues = new ErrorValues(errorReport);
                     errorReports.put(key, errorValues);


### PR DESCRIPTION
The ideal state would be that only the [n] most common errors are saved complete with their stacktrace, but this can't be determinded at the time of saving, so let's put this in a followup issue in case we find a solution at some point, otherwise this will be sufficient to be able to avoid memory problems at report creation.