### PR TITLE
GH #501: ErrorCounter timer thread prevents JVM to exit

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/resultbrowser/ErrorCounter.java
+++ b/src/main/java/com/xceptance/xlt/engine/resultbrowser/ErrorCounter.java
@@ -149,7 +149,7 @@ public class ErrorCounter
         this.resetInterval = tmpInterval * 1000;
         if (resetInterval > 0)
         {
-            timer = new Timer("ErrorCounter-ResetTimer");
+            timer = new Timer("ErrorCounter-ResetTimer", true);
         }
         else
         {


### PR DESCRIPTION
Changes:
- create Timer thread as daemon thread such that VM can shutdown when all user threads have terminated

Closes #501.