### PR TITLE
GH 502: Real-time metrics reporting stopped working in XLT 7.0.0

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/DataManagerImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/DataManagerImpl.java
@@ -21,6 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import com.xceptance.common.util.CsvUtils;
 import com.xceptance.xlt.api.engine.Data;
@@ -70,9 +72,9 @@ public class DataManagerImpl implements DataManager
     private volatile BufferedWriter logger;
 
     /**
-     * Our reference to metrics
+     * Our metrics provider.
      */
-    private final Metrics metrics;
+    private final Supplier<Metrics> metrics;
 
     /**
      * Back-reference to session using this data manager.
@@ -88,9 +90,9 @@ public class DataManagerImpl implements DataManager
      * @param session
      *            the session that should use this data manager
      * @param metrics
-     *            a metrics target for real time loggiing
+     *            a metrics target for real time logging
      */
-    protected DataManagerImpl(final Session session, final Metrics metrics)
+    protected DataManagerImpl(final Session session, final Supplier<Metrics> metrics)
     {
         this.session = session;
         this.metrics = metrics;
@@ -104,8 +106,7 @@ public class DataManagerImpl implements DataManager
      */
     protected DataManagerImpl(final Session session)
     {
-        this.session = session;
-        this.metrics = null;
+        this(session, null);
     }
 
     /**
@@ -139,10 +140,7 @@ public class DataManagerImpl implements DataManager
     public void logDataRecord(final Data stats)
     {
         // update metrics for real-time reporting
-        if (metrics != null)
-        {
-            metrics.updateMetrics(stats);
-        }
+        Optional.ofNullable(metrics).map(Supplier::get).ifPresent((m) -> m.updateMetrics(stats));
 
         // Check whether the data record falls into the logging period.
         // Take the data record's (start) time as the criterion.

--- a/src/main/java/com/xceptance/xlt/engine/SessionImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/SessionImpl.java
@@ -323,7 +323,7 @@ public class SessionImpl extends Session
         totalAgentCount = 1;
 
         // create the session-specific helper objects
-        dataManagerImpl = new DataManagerImpl(this, Metrics.getInstance());
+        dataManagerImpl = new DataManagerImpl(this, Metrics::getInstance);
         shutdownListeners = new ArrayList<SessionShutdownListener>();
         networkDataManagerImpl = new NetworkDataManagerImpl();
 

--- a/src/test/java/com/xceptance/xlt/engine/DataManagerImplTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/DataManagerImplTest.java
@@ -77,7 +77,7 @@ public class DataManagerImplTest
     public void loggingPeriod() throws IOException
     {
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         dm.setStartOfLoggingPeriod(8000L);
         dm.setEndOfLoggingPeriod(9000L);
@@ -125,7 +125,7 @@ public class DataManagerImplTest
         GlobalClock.installFixed(1666646047921L);
 
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         dm.enableLogging();
         assertTrue(dm.isLoggingEnabled());
@@ -161,7 +161,7 @@ public class DataManagerImplTest
         GlobalClock.installFixed(1666646047921L);
 
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         dm.setLoggingEnabled(true);
         assertTrue(dm.isLoggingEnabled());
@@ -198,7 +198,7 @@ public class DataManagerImplTest
         GlobalClock.installFixed(1666646047921L);
 
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         dm.logEvent("EventName1", "Just a message1");
 
@@ -226,7 +226,7 @@ public class DataManagerImplTest
         GlobalClock.installFixed(1666646047921L);
 
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         dm.logEvent("EventName", "Just a message");
 
@@ -293,7 +293,7 @@ public class DataManagerImplTest
     public void dontCountOtherThanEvent() throws IOException
     {
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         var c = new CustomData("Custom");
         c.setTime(1000L);
@@ -315,7 +315,7 @@ public class DataManagerImplTest
     public void logEventAppend() throws IOException
     {
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         GlobalClock.installFixed(1666646047921L);
         dm.logEvent("EventName1", "M1");
@@ -328,7 +328,7 @@ public class DataManagerImplTest
         session.clear();
 
         session = new TestSession("TName");
-        dm = new DataManagerImpl(session, metrics);
+        dm = new DataManagerImpl(session, () -> metrics);
 
         GlobalClock.installFixed(1666646047923L);
         dm.logEvent("EventName3", "M3");
@@ -357,7 +357,7 @@ public class DataManagerImplTest
     public void numberOfEvents()
     {
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         GlobalClock.installFixed(1666646047921L);
         dm.logEvent("EventName1", "M1");
@@ -376,7 +376,7 @@ public class DataManagerImplTest
     public void directLogging() throws IOException
     {
         var session = new TestSession("TName");
-        var dm = new DataManagerImpl(session, metrics);
+        var dm = new DataManagerImpl(session, () -> metrics);
 
         var e = new EventData();
         e.setTime(1000L);


### PR DESCRIPTION
Changes:
- invoke 'Metrics.getInstance()' as late as possible such that session is properly initialized (esp. its 'loadTest' flag)
- fix broken unit tests

Closes #502