### PR TITLE
#535: No measurements after resetting the web client

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
+++ b/src/main/java/com/xceptance/xlt/engine/XltWebClient.java
@@ -316,7 +316,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
         // JavaScript
         getOptions().setJavaScriptEnabled(props.getProperty("com.xceptance.xlt.javaScriptEnabled", false));
         getOptions().setThrowExceptionOnScriptError(props.getProperty("com.xceptance.xlt.stopTestOnJavaScriptErrors", false));
-        setUpJavaScriptEngine(props);
+        configureJavaScriptEngine(props);
 
         // default user authentication
         final String userName = props.getProperty("com.xceptance.xlt.auth.userName");
@@ -419,11 +419,11 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
         getOptions().setHistorySizeLimit(historySizeLimit);
 
         // set web connection
-        setUpWebConnection(props);
+        configureWebConnection(props);
 
         // load key/trust material for client/server authentication
-        setUpKeyStore(props);
-        setUpTrustStore(props);
+        configureKeyStore(props);
+        configureTrustStore(props);
     }
 
     /**
@@ -437,10 +437,10 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
         final XltProperties props = XltProperties.getInstance();
 
         // create a new instance of "our" JavaScript engine if needed
-        setUpJavaScriptEngine(props);
+        configureJavaScriptEngine(props);
 
         // create a new instance of "our" web connection
-        setUpWebConnection(props);
+        configureWebConnection(props);
 
         pageLocalCache.clear();
     }
@@ -2030,7 +2030,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      * @param props
      *            the configuration
      */
-    private void setUpJavaScriptEngine(final XltProperties props)
+    private void configureJavaScriptEngine(final XltProperties props)
     {
         if (isJavaScriptEngineEnabled())
         {
@@ -2066,7 +2066,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      * @param props
      *            the configuration
      */
-    private void setUpWebConnection(final XltProperties props)
+    private void configureWebConnection(final XltProperties props)
     {
         final WebConnection underlyingWebConnection;
         if (props.getProperty("com.xceptance.xlt.http.offline", false))
@@ -2103,7 +2103,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      * @param props
      *            the configuration
      */
-    private void setUpKeyStore(final XltProperties props)
+    private void configureKeyStore(final XltProperties props)
     {
         final String storeFilePath = props.getProperty("com.xceptance.xlt.tls.keyStore.file");
         if (StringUtils.isNotBlank(storeFilePath))
@@ -2123,7 +2123,7 @@ public class XltWebClient extends WebClient implements SessionShutdownListener, 
      * @param props
      *            the configuration
      */
-    private void setUpTrustStore(final XltProperties props)
+    private void configureTrustStore(final XltProperties props)
     {
         final String storeFilePath = props.getProperty("com.xceptance.xlt.tls.trustStore.file");
         if (StringUtils.isNotBlank(storeFilePath))

--- a/src/test/java/com/xceptance/xlt/engine/XltWebClientTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/XltWebClientTest.java
@@ -22,7 +22,9 @@ import java.util.Set;
 
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.MockWebConnection;
+import org.htmlunit.WebConnection;
 import org.htmlunit.WebResponse;
+import org.htmlunit.javascript.AbstractJavaScriptEngine;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -203,16 +205,42 @@ public class XltWebClientTest extends AbstractXLTTestCase
         }
     }
 
+    @Test
+    public void testReset()
+    {
+        try (final XltWebClient webClient = new XltWebClient(BrowserVersion.BEST_SUPPORTED, true))
+        {
+            // prevalidation
+            final WebConnection webConnection = webClient.getWebConnection();
+            final AbstractJavaScriptEngine<?> javaScriptEngine = webClient.getJavaScriptEngine();
+
+            Assert.assertEquals("Unexpected WebConnection class", XltHttpWebConnection.class, webConnection.getClass());
+            Assert.assertEquals("Unexpected JavaScriptEngine class", XltJavaScriptEngine.class, javaScriptEngine.getClass());
+
+            // reset
+            webClient.reset();
+
+            // validate that web connection and javascript engine are still XLT classes, but different objects
+            final WebConnection newWebConnection = webClient.getWebConnection();
+            final AbstractJavaScriptEngine<?> newJavaScriptEngine = webClient.getJavaScriptEngine();
+
+            Assert.assertEquals("Unexpected WebConnection class", XltHttpWebConnection.class, newWebConnection.getClass());
+            Assert.assertEquals("Unexpected JavaScriptEngine class", XltJavaScriptEngine.class, newJavaScriptEngine.getClass());
+
+            Assert.assertNotEquals("WebConnection is the same as before", webConnection, newWebConnection);
+            Assert.assertNotEquals("JavaScriptEngine is the same as before", javaScriptEngine, newJavaScriptEngine);
+        }
+    }
+
     /**
      * Response processor which simple stores the request URLs.
      */
     static class URLCollector implements ResponseProcessor
     {
         /**
-         * Collected URLs.
-         * This has to be a synchronized set because some of the processing runs in another thread and hence
-         * we might experiencene false sharing otherwise, mainly because a response processor is not designed
-         * to be a data collector
+         * Collected URLs. This has to be a synchronized set because some of the processing runs in another thread and
+         * hence we might experiencene false sharing otherwise, mainly because a response processor is not designed to
+         * be a data collector
          */
         private final Set<URL> urls = Collections.synchronizedSet(new HashSet<URL>());
 


### PR DESCRIPTION
When resetting the Web client, make sure the JavaScript engine and Web connection are recreated using XLT classes.