### PR TITLE
#572: API signature validation fails when run with Ant v1.10.14+ and Java21

### DIFF
--- a/ant-scripts/sigtest.xml
+++ b/ant-scripts/sigtest.xml
@@ -29,7 +29,7 @@
         </sigsetup>
         -->
         <!-- Run sigtest directly so we can pass parameters not supported yet by the Ant task. -->
-        <java classname="com.sun.tdk.signaturetest.Setup" resultproperty="setup.exitcode">
+        <java classname="com.sun.tdk.signaturetest.Setup" resultproperty="setup.exitcode" fork="yes">
             <classpath refid="classpath" />
             <arg value="-ApiVersion" />
             <arg value="${version}" />
@@ -58,7 +58,7 @@
         </sigtest>
         -->
         <!-- Run sigtest directly so we can pass parameters not supported yet by the Ant task. -->
-        <java classname="com.sun.tdk.signaturetest.SignatureTest" resultproperty="apicheck.exitcode">
+        <java classname="com.sun.tdk.signaturetest.SignatureTest" resultproperty="apicheck.exitcode" fork="yes">
             <classpath refid="classpath" />
             <arg value="-ApiVersion" />
             <arg value="${version}" />


### PR DESCRIPTION
* run sigtest as forked JVM to overcome issues with newer Ant versions
* updated sigtest library for better compatibility with Java 21 (target "sigsetup" works again)