### PR TITLE
GH #588: Allow to skip unreachable agent controllers when running in commands mode

### DIFF
--- a/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerMain.java
+++ b/src/main/java/com/xceptance/xlt/mastercontroller/MasterControllerMain.java
@@ -107,7 +107,7 @@ public class MasterControllerMain
 
         // restrict relaxed connections to 'auto' or commands mode
         final boolean isAgentControllerConnectionRelaxed = config.isAgentControllerConnectionRelaxed() &&
-                                                           (commandLine.hasOption(OPTION_AUTO) || commandsMode);
+                                                           (autoMode || commandsMode);
 
         // restrict results override to non-sequential 'auto' mode or commands mode
         if ((autoMode && !sequentialMode || commandsMode) && commandLine.hasOption(OPTION_RESULT_OVERRIDE))


### PR DESCRIPTION
Include test for commands mode in conditional expression used to compute effective setting of 'ignore unreachable agent controllers' feature.

Closes #588.