### PR TITLE
#584 Show pointer when hovering over slowest requests links

### DIFF
--- a/config/testreport/js/xlt.js
+++ b/config/testreport/js/xlt.js
@@ -1,7 +1,7 @@
 (function($){
 
     function navigate(target) {
-        if (target != null) {
+        if (target) {
             // does it contain a #
             var pos = target.lastIndexOf("#");
 

--- a/config/xsl/loadreport/util/slowest-requests-table.xsl
+++ b/config/xsl/loadreport/util/slowest-requests-table.xsl
@@ -199,6 +199,8 @@
         <xsl:choose>
             <xsl:when test="$showRequestInfo or $showResponseInfo">
                 <a>
+                    <xsl:attribute name="href"/>
+                    <xsl:attribute name="onclick">return false;</xsl:attribute>
                     <xsl:attribute name="data-rel">#request-details-<xsl:value-of select="$gid"/></xsl:attribute>
                     <xsl:attribute name="class">cluetip</xsl:attribute>
                     <xsl:value-of select="$name"/>
@@ -286,6 +288,8 @@
             <xsl:choose>
                 <xsl:when test="$ipAddressCount &gt; 1">
                     <a>
+                        <xsl:attribute name="href"/>
+                        <xsl:attribute name="onclick">return false;</xsl:attribute>
                         <xsl:attribute name="data-rel">#reported-ip-list-<xsl:value-of select="$gid"/></xsl:attribute>
                         <xsl:attribute name="class">cluetip</xsl:attribute>
                         <xsl:value-of select="$ipAddressCount"/> IP Addresses


### PR DESCRIPTION
See: https://github.com/Xceptance/XLT/issues/584

**Note:** If multiple IP addresses were reported for a request, another link is shown in the "Reported" column of the table. The pointer behavior was fixed for this link as well, since it had the same issue.

**Details:**
The pointer wasn't shown because the links had no "href" attribute, so the attribute was added. The request names are currently only links for visual clarity and don't link to anything, though, so I also had to overwrite the default link behavior, so the links do nothing when clicked.