### PR TITLE
#606: Custom cookies may not be working with OkHttp

### DIFF
--- a/src/main/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImpl.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.htmlunit.CookieManager;
 import org.htmlunit.util.Cookie;
 
@@ -32,9 +31,7 @@ import okhttp3.HttpUrl;
  */
 class CookieJarImpl implements CookieJar
 {
-    static final String ERROR_MSG_DOMAIN = "Domain not set in cookie";
-
-    static final String ERROR_MSG_PATH = "Path not set or does not start with '/' in cookie";
+    static final String ERROR_MSG_COOKIE_INVALID = "Cookie not valid for use with OkHttp";
 
     /**
      * HtmlUnit's cookie manager.
@@ -101,60 +98,53 @@ class CookieJarImpl implements CookieJar
      */
     static okhttp3.Cookie toOkHttpCookie(final Cookie htmlUnitCookie)
     {
-        final Builder builder = new okhttp3.Cookie.Builder();
-
-        final String domain = StringUtils.defaultString(htmlUnitCookie.getDomain()).trim();
-        if (!domain.isEmpty())
+        try
         {
+            final Builder builder = new okhttp3.Cookie.Builder();
+
+            builder.name(htmlUnitCookie.getName());
+            builder.value(htmlUnitCookie.getValue());
+
+            final String domain = htmlUnitCookie.getDomain();
             if (domain.startsWith("."))
             {
                 // "wildcard" domain, such as ".example.com"
                 // the cookie builder expects the domain to be passed without the leading dot
-                builder.domain(StringUtils.stripStart(domain, "."));
+                builder.domain(domain.substring(1));
             }
             else
             {
                 // "host" domain, such as "www.example.com"
                 builder.hostOnlyDomain(domain);
             }
+
+            final String path = htmlUnitCookie.getPath();
+            if (path != null)
+            {
+                builder.path(path);
+            }
+
+            final Date expires = htmlUnitCookie.getExpires();
+            if (expires != null)
+            {
+                builder.expiresAt(expires.getTime());
+            }
+
+            if (htmlUnitCookie.isSecure())
+            {
+                builder.secure();
+            }
+
+            if (htmlUnitCookie.isHttpOnly())
+            {
+                builder.httpOnly();
+            }
+
+            return builder.build();
         }
-        else
+        catch (final Exception e)
         {
-            throw new IllegalArgumentException(ERROR_MSG_DOMAIN + ": '" + htmlUnitCookie + "'");
+            throw new IllegalArgumentException(ERROR_MSG_COOKIE_INVALID + ": '" + htmlUnitCookie + "'", e);
         }
-
-        final String name = StringUtils.defaultString(htmlUnitCookie.getName()).trim();
-        builder.name(name);
-
-        final String value = StringUtils.defaultString(htmlUnitCookie.getValue()).trim();
-        builder.value(value);
-
-        final String path = StringUtils.defaultString(htmlUnitCookie.getPath()).trim();
-        if (path.startsWith("/"))
-        {
-            builder.path(path);
-        }
-        else
-        {
-            throw new IllegalArgumentException(ERROR_MSG_PATH + ": '" + htmlUnitCookie + "'");
-        }
-
-        final Date expires = htmlUnitCookie.getExpires();
-        if (expires != null)
-        {
-            builder.expiresAt(expires.getTime());
-        }
-
-        if (htmlUnitCookie.isSecure())
-        {
-            builder.secure();
-        }
-
-        if (htmlUnitCookie.isHttpOnly())
-        {
-            builder.httpOnly();
-        }
-
-        return builder.build();
     }
 }

--- a/src/main/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImpl.java
+++ b/src/main/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImpl.java
@@ -32,6 +32,10 @@ import okhttp3.HttpUrl;
  */
 class CookieJarImpl implements CookieJar
 {
+    static final String ERROR_MSG_DOMAIN = "Domain not set in cookie";
+
+    static final String ERROR_MSG_PATH = "Path not set or does not start with '/' in cookie";
+
     /**
      * HtmlUnit's cookie manager.
      */
@@ -95,24 +99,50 @@ class CookieJarImpl implements CookieJar
      *            the source cookie
      * @return the converted cookie
      */
-    private static okhttp3.Cookie toOkHttpCookie(final Cookie htmlUnitCookie)
+    static okhttp3.Cookie toOkHttpCookie(final Cookie htmlUnitCookie)
     {
         final Builder builder = new okhttp3.Cookie.Builder();
 
-        builder.name(htmlUnitCookie.getName()).value(htmlUnitCookie.getValue()).path(htmlUnitCookie.getPath())
-               .expiresAt(htmlUnitCookie.getExpires().getTime());
-
-        final String domain = htmlUnitCookie.getDomain();
-        if (domain.startsWith("."))
+        final String domain = StringUtils.defaultString(htmlUnitCookie.getDomain()).trim();
+        if (!domain.isEmpty())
         {
-            // "wildcard" domain, such as ".example.com"
-            // the cookie builder expects the domain to be passed without the leading dot
-            builder.domain(StringUtils.stripStart(domain, "."));
+            if (domain.startsWith("."))
+            {
+                // "wildcard" domain, such as ".example.com"
+                // the cookie builder expects the domain to be passed without the leading dot
+                builder.domain(StringUtils.stripStart(domain, "."));
+            }
+            else
+            {
+                // "host" domain, such as "www.example.com"
+                builder.hostOnlyDomain(domain);
+            }
         }
         else
         {
-            // "host" domain, such as "www.example.com"
-            builder.hostOnlyDomain(domain);
+            throw new IllegalArgumentException(ERROR_MSG_DOMAIN + ": '" + htmlUnitCookie + "'");
+        }
+
+        final String name = StringUtils.defaultString(htmlUnitCookie.getName()).trim();
+        builder.name(name);
+
+        final String value = StringUtils.defaultString(htmlUnitCookie.getValue()).trim();
+        builder.value(value);
+
+        final String path = StringUtils.defaultString(htmlUnitCookie.getPath()).trim();
+        if (path.startsWith("/"))
+        {
+            builder.path(path);
+        }
+        else
+        {
+            throw new IllegalArgumentException(ERROR_MSG_PATH + ": '" + htmlUnitCookie + "'");
+        }
+
+        final Date expires = htmlUnitCookie.getExpires();
+        if (expires != null)
+        {
+            builder.expiresAt(expires.getTime());
         }
 
         if (htmlUnitCookie.isSecure())

--- a/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2005-2025 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.engine.htmlunit.okhttp3;
+
+import org.htmlunit.util.Cookie;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import util.JUnitParamsUtils;
+import util.JUnitParamsUtils.BlankStringParamProvider;
+
+@RunWith(JUnitParamsRunner.class)
+public class CookieJarImplTest
+{
+    @Test
+    @Parameters(source = BlankStringParamProvider.class)
+    public void toOkHttpCookie_BlankDomain(final String domain)
+    {
+        callToOkHttpCookieButExpectedException(new Cookie(domain, "name", "value", "/", null, false, false),
+                                               CookieJarImpl.ERROR_MSG_DOMAIN);
+    }
+
+    @Test
+    @Parameters(source = DomainDataProvider.class)
+    public void toOkHttpCookie_ValidDomain(final String domain, final boolean expectedHostOnly)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(domain, "name", "value", "/", null, false, false));
+
+        Assert.assertEquals("example.com", okCookie.domain());
+        Assert.assertEquals(expectedHostOnly, okCookie.hostOnly());
+    }
+
+    @Test
+    @Parameters(source = BlankStringParamProvider.class)
+    public void toOkHttpCookie_BlankName(final String name)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", name, "value", "/", null, false, false));
+
+        Assert.assertEquals("", okCookie.name());
+    }
+
+    @Test
+    @Parameters(source = NameProvider.class)
+    public void toOkHttpCookie_ValidName(final String name)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", name, "value", "/", null, false, false));
+
+        Assert.assertEquals("name", okCookie.name());
+    }
+
+    @Test
+    @Parameters(source = BlankStringParamProvider.class)
+    public void toOkHttpCookie_BlankValue(final String name)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", name, "value", "/", null, false, false));
+
+        Assert.assertEquals("", okCookie.name());
+    }
+
+    @Test
+    @Parameters(source = ValueProvider.class)
+    public void toOkHttpCookie_ValidValue(final String value)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", "name", value, "/", null, false, false));
+
+        Assert.assertEquals("value", okCookie.value());
+    }
+
+    @Test
+    @Parameters(source = BlankStringParamProvider.class)
+    public void toOkHttpCookie_BlankPath(final String path)
+    {
+        callToOkHttpCookieButExpectedException(new Cookie("domain", "name", "value", path, null, false, false),
+                                               CookieJarImpl.ERROR_MSG_PATH);
+    }
+
+    @Test
+    @Parameters(source = PathProvider.class)
+    public void toOkHttpCookie_ValidPath(final String path)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", "name", "value", path, null, false, false));
+
+        Assert.assertEquals("/path", okCookie.path());
+    }
+
+    @Test
+    public void toOkHttpCookie_InvalidPath()
+    {
+        callToOkHttpCookieButExpectedException(new Cookie("domain", "name", "value", "path_not_starting_with_slash", null, false, false),
+                                               CookieJarImpl.ERROR_MSG_PATH);
+    }
+
+    private void callToOkHttpCookieButExpectedException(final Cookie huCookie, final String expectedMessagePrefix)
+    {
+        try
+        {
+            CookieJarImpl.toOkHttpCookie(huCookie);
+            Assert.fail("Expected IllegalArgumentException");
+        }
+        catch (final IllegalArgumentException e)
+        {
+            Assert.assertTrue("Unexpected exception message", e.getMessage().startsWith(expectedMessagePrefix));
+        }
+    }
+
+    public static class DomainDataProvider
+    {
+        public static Object[][] provide()
+        {
+            return JUnitParamsUtils.parseParamSets("example.com|true",      //
+                                                     " example.com |true",    //
+                                                     ".example.com|false",    //
+                                                     " .example.com |false");
+        }
+    }
+
+    public static class NameProvider
+    {
+        public static Object[][] provide()
+        {
+            return JUnitParamsUtils.parseParamSets("name", " name ");
+        }
+    }
+
+    public static class ValueProvider
+    {
+        public static Object[][] provide()
+        {
+            return JUnitParamsUtils.parseParamSets("value", " value ");
+        }
+    }
+
+    public static class PathProvider
+    {
+        public static Object[][] provide()
+        {
+            return JUnitParamsUtils.parseParamSets("/path", " /path ");
+        }
+    }
+}

--- a/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import util.JUnitParamsUtils;
+import util.JUnitParamsUtils.BlankStringOrNullParamProvider;
 import util.JUnitParamsUtils.BlankStringParamProvider;
 
 @RunWith(JUnitParamsRunner.class)
@@ -32,8 +33,7 @@ public class CookieJarImplTest
     @Parameters(source = BlankStringParamProvider.class)
     public void toOkHttpCookie_BlankDomain(final String domain)
     {
-        callToOkHttpCookieButExpectedException(new Cookie(domain, "name", "value", "/", null, false, false),
-                                               CookieJarImpl.ERROR_MSG_DOMAIN);
+        callToOkHttpCookieButExpectException(new Cookie(domain, "name", "value", "/", null, false, false), CookieJarImpl.ERROR_MSG_DOMAIN);
     }
 
     @Test
@@ -65,12 +65,12 @@ public class CookieJarImplTest
     }
 
     @Test
-    @Parameters(source = BlankStringParamProvider.class)
-    public void toOkHttpCookie_BlankValue(final String name)
+    @Parameters(source = BlankStringOrNullParamProvider.class)
+    public void toOkHttpCookie_BlankValue(final String value)
     {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", name, "value", "/", null, false, false));
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", "name", value, "/", null, false, false));
 
-        Assert.assertEquals("", okCookie.name());
+        Assert.assertEquals("", okCookie.value());
     }
 
     @Test
@@ -83,11 +83,10 @@ public class CookieJarImplTest
     }
 
     @Test
-    @Parameters(source = BlankStringParamProvider.class)
+    @Parameters(source = BlankStringOrNullParamProvider.class)
     public void toOkHttpCookie_BlankPath(final String path)
     {
-        callToOkHttpCookieButExpectedException(new Cookie("domain", "name", "value", path, null, false, false),
-                                               CookieJarImpl.ERROR_MSG_PATH);
+        callToOkHttpCookieButExpectException(new Cookie("domain", "name", "value", path, null, false, false), CookieJarImpl.ERROR_MSG_PATH);
     }
 
     @Test
@@ -102,11 +101,11 @@ public class CookieJarImplTest
     @Test
     public void toOkHttpCookie_InvalidPath()
     {
-        callToOkHttpCookieButExpectedException(new Cookie("domain", "name", "value", "path_not_starting_with_slash", null, false, false),
-                                               CookieJarImpl.ERROR_MSG_PATH);
+        callToOkHttpCookieButExpectException(new Cookie("domain", "name", "value", "path_not_starting_with_slash", null, false, false),
+                                             CookieJarImpl.ERROR_MSG_PATH);
     }
 
-    private void callToOkHttpCookieButExpectedException(final Cookie huCookie, final String expectedMessagePrefix)
+    private void callToOkHttpCookieButExpectException(final Cookie huCookie, final String expectedMessagePrefix)
     {
         try
         {
@@ -124,9 +123,9 @@ public class CookieJarImplTest
         public static Object[][] provide()
         {
             return JUnitParamsUtils.parseParamSets("example.com|true",      //
-                                                     " example.com |true",    //
-                                                     ".example.com|false",    //
-                                                     " .example.com |false");
+                                                   " example.com |true",    //
+                                                   ".example.com|false",    //
+                                                   " .example.com |false");
         }
     }
 

--- a/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
@@ -15,141 +15,190 @@
  */
 package com.xceptance.xlt.engine.htmlunit.okhttp3;
 
+import java.util.Date;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.htmlunit.util.Cookie;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.threeten.bp.Instant;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import okhttp3.internal.http.DatesKt;
 import util.JUnitParamsUtils;
-import util.JUnitParamsUtils.BlankStringOrNullParamProvider;
 import util.JUnitParamsUtils.BlankStringParamProvider;
 
 @RunWith(JUnitParamsRunner.class)
 public class CookieJarImplTest
 {
+    private static final String DOMAIN = "domain";
+
+    private static final String NAME = "name";
+
+    private static final String VALUE = "value";
+
+    private static final String PATH = "/";
+
+    private static final Date EXPIRES_AT = null;
+
+    private static final boolean SECURE = false;
+
+    private static final boolean HTTP_ONLY = false;
+
     @Test
-    @Parameters(source = BlankStringParamProvider.class)
-    public void toOkHttpCookie_BlankDomain(final String domain)
+    @Parameters(source = InvalidDomainProvider.class)
+    public void toOkHttpCookie_Domain_Invalid(final String domain)
     {
-        callToOkHttpCookieButExpectException(new Cookie(domain, "name", "value", "/", null, false, false), CookieJarImpl.ERROR_MSG_DOMAIN);
+        callToOkHttpCookieButExpectException(new Cookie(domain, NAME, VALUE, PATH, EXPIRES_AT, SECURE, HTTP_ONLY));
     }
 
     @Test
-    @Parameters(source = DomainDataProvider.class)
-    public void toOkHttpCookie_ValidDomain(final String domain, final boolean expectedHostOnly)
+    @Parameters(
+        {
+            "example.com|true", ".example.com|false"
+    })
+    public void toOkHttpCookie_Domain_Valid(final String domain, final boolean expectedHostOnly)
     {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(domain, "name", "value", "/", null, false, false));
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(domain, NAME, VALUE, PATH, EXPIRES_AT, SECURE, HTTP_ONLY));
 
         Assert.assertEquals("example.com", okCookie.domain());
         Assert.assertEquals(expectedHostOnly, okCookie.hostOnly());
     }
 
     @Test
-    @Parameters(source = BlankStringParamProvider.class)
-    public void toOkHttpCookie_BlankName(final String name)
+    @Parameters(source = InvalidNameProvider.class)
+    public void toOkHttpCookie_Name_Invalid(final String name)
     {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", name, "value", "/", null, false, false));
-
-        Assert.assertEquals("", okCookie.name());
+        callToOkHttpCookieButExpectException(new Cookie(DOMAIN, name, VALUE, PATH, EXPIRES_AT, SECURE, HTTP_ONLY));
     }
 
     @Test
-    @Parameters(source = NameProvider.class)
-    public void toOkHttpCookie_ValidName(final String name)
-    {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", name, "value", "/", null, false, false));
-
-        Assert.assertEquals("name", okCookie.name());
-    }
-
-    @Test
-    @Parameters(source = BlankStringOrNullParamProvider.class)
-    public void toOkHttpCookie_BlankValue(final String value)
-    {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", "name", value, "/", null, false, false));
-
-        Assert.assertEquals("", okCookie.value());
-    }
-
-    @Test
-    @Parameters(source = ValueProvider.class)
-    public void toOkHttpCookie_ValidValue(final String value)
-    {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", "name", value, "/", null, false, false));
-
-        Assert.assertEquals("value", okCookie.value());
-    }
-
-    @Test
-    @Parameters(source = BlankStringOrNullParamProvider.class)
-    public void toOkHttpCookie_BlankPath(final String path)
-    {
-        callToOkHttpCookieButExpectException(new Cookie("domain", "name", "value", path, null, false, false), CookieJarImpl.ERROR_MSG_PATH);
-    }
-
-    @Test
-    @Parameters(source = PathProvider.class)
-    public void toOkHttpCookie_ValidPath(final String path)
-    {
-        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie("domain", "name", "value", path, null, false, false));
-
-        Assert.assertEquals("/path", okCookie.path());
-    }
-
-    @Test
-    public void toOkHttpCookie_InvalidPath()
-    {
-        callToOkHttpCookieButExpectException(new Cookie("domain", "name", "value", "path_not_starting_with_slash", null, false, false),
-                                             CookieJarImpl.ERROR_MSG_PATH);
-    }
-
-    private void callToOkHttpCookieButExpectException(final Cookie huCookie, final String expectedMessagePrefix)
-    {
-        try
+    @Parameters(
         {
-            CookieJarImpl.toOkHttpCookie(huCookie);
-            Assert.fail("Expected IllegalArgumentException");
-        }
-        catch (final IllegalArgumentException e)
-        {
-            Assert.assertTrue("Unexpected exception message", e.getMessage().startsWith(expectedMessagePrefix));
-        }
+            NAME, ""
+    })
+    public void toOkHttpCookie_Name_Valid(final String name)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(DOMAIN, name, VALUE, PATH, EXPIRES_AT, SECURE, HTTP_ONLY));
+
+        Assert.assertEquals(name, okCookie.name());
     }
 
-    public static class DomainDataProvider
+    @Test
+    @Parameters(source = InvalidValueProvider.class)
+    public void toOkHttpCookie_Value_Invalid(final String value)
+    {
+        callToOkHttpCookieButExpectException(new Cookie(DOMAIN, NAME, value, PATH, EXPIRES_AT, SECURE, HTTP_ONLY));
+    }
+
+    @Test
+    @Parameters(
+        {
+            VALUE, ""
+    })
+    public void toOkHttpCookie_Value_Valid(final String value)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(DOMAIN, NAME, value, PATH, EXPIRES_AT, SECURE, HTTP_ONLY));
+
+        Assert.assertEquals(value, okCookie.value());
+    }
+
+    @Test
+    @Parameters(source = InvalidPathProvider.class)
+    public void toOkHttpCookie_Path_Invalid(final String path)
+    {
+        callToOkHttpCookieButExpectException(new Cookie(DOMAIN, NAME, VALUE, path, EXPIRES_AT, SECURE, HTTP_ONLY));
+    }
+
+    @Test
+    @Parameters(
+        {
+            PATH, "/path", "/path/path"
+    })
+    public void toOkHttpCookie_Path_Valid(final String path)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(DOMAIN, NAME, VALUE, path, EXPIRES_AT, SECURE, HTTP_ONLY));
+
+        Assert.assertEquals(path, okCookie.path());
+    }
+
+    @Test
+    public void toOkHttpCookie_Path_Null()
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(DOMAIN, NAME, VALUE, null, EXPIRES_AT, SECURE, HTTP_ONLY));
+
+        Assert.assertEquals(PATH, okCookie.path());
+    }
+
+    @Test
+    public void toOkHttpCookie_ExpiresAt_Null()
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(DOMAIN, NAME, VALUE, PATH, null, SECURE, HTTP_ONLY));
+
+        Assert.assertEquals(DatesKt.MAX_DATE, okCookie.expiresAt());
+    }
+
+    @Test
+    @Parameters(source = ExpiresAtProvider.class)
+    public void toOkHttpCookie_ExpiresAt_Valid(final Date expiresAt)
+    {
+        final var okCookie = CookieJarImpl.toOkHttpCookie(new Cookie(DOMAIN, NAME, VALUE, PATH, expiresAt, SECURE, HTTP_ONLY));
+
+        Assert.assertEquals(expiresAt.getTime(), okCookie.expiresAt());
+    }
+
+    // --- Helpers and data providers ---
+
+    private void callToOkHttpCookieButExpectException(final Cookie huCookie)
+    {
+        final IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                                                                       () -> CookieJarImpl.toOkHttpCookie(huCookie));
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.startsWith(CookieJarImpl.ERROR_MSG_COOKIE_INVALID));
+    }
+
+    public static class InvalidDomainProvider extends BlankStringParamProvider
     {
         public static Object[][] provide()
         {
-            return JUnitParamsUtils.parseParamSets("example.com|true",      //
-                                                   " example.com |true",    //
-                                                   ".example.com|false",    //
-                                                   " .example.com |false");
+            return JUnitParamsUtils.wrapEachParam(".", " example.com ", " .example.com ");
         }
     }
 
-    public static class NameProvider
+    public static class InvalidNameProvider
     {
         public static Object[][] provide()
         {
-            return JUnitParamsUtils.parseParamSets("name", " name ");
+            return JUnitParamsUtils.wrapEachParam(" ", " name", "name ", " name ");
         }
     }
 
-    public static class ValueProvider
+    public static class InvalidValueProvider
     {
         public static Object[][] provide()
         {
-            return JUnitParamsUtils.parseParamSets("value", " value ");
+            return JUnitParamsUtils.wrapEachParam(" ", " value", "value ", " value ");
         }
     }
 
-    public static class PathProvider
+    public static class InvalidPathProvider extends BlankStringParamProvider
     {
         public static Object[][] provide()
         {
-            return JUnitParamsUtils.parseParamSets("/path", " /path ");
+            return JUnitParamsUtils.wrapEachParam("path", " /path ");
+        }
+    }
+
+    public static class ExpiresAtProvider
+    {
+        public static Object[][] provide()
+        {
+            final Instant now = Instant.now();
+
+            return JUnitParamsUtils.wrapEachParam(new Date(), new Date(now.minusSeconds(1000).toEpochMilli()),
+                                                  new Date(now.plusSeconds(1000).toEpochMilli()));
         }
     }
 }

--- a/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
+++ b/src/test/java/com/xceptance/xlt/engine/htmlunit/okhttp3/CookieJarImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.xceptance.xlt.engine.htmlunit.okhttp3;
 
+import java.time.Instant;
 import java.util.Date;
 
 import org.hamcrest.CoreMatchers;
@@ -23,7 +24,6 @@ import org.htmlunit.util.Cookie;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.Instant;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;

--- a/src/test/java/util/JUnitParamsUtils.java
+++ b/src/test/java/util/JUnitParamsUtils.java
@@ -102,7 +102,7 @@ public class JUnitParamsUtils
      * @return an Object array containing one Object array for each parameter; each of the inner Object arrays contains
      *         a single parameter
      */
-    public static Object[][] wrapEachParam(final Object[] params)
+    public static Object[][] wrapEachParam(final Object... params)
     {
         return Arrays.stream(params).map(JUnitParamsUtils::wrapParams).toArray(Object[][]::new);
     }

--- a/src/test/java/util/JUnitParamsUtils.java
+++ b/src/test/java/util/JUnitParamsUtils.java
@@ -17,6 +17,8 @@ package util;
 
 import java.util.Arrays;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Util class to assist in running tests with JUnitParams. Contains helper methods and common test parameter providers.
  */
@@ -103,5 +105,37 @@ public class JUnitParamsUtils
     public static Object[][] wrapEachParam(final Object[] params)
     {
         return Arrays.stream(params).map(JUnitParamsUtils::wrapParams).toArray(Object[][]::new);
+    }
+
+    /**
+     * Parses the given parameter set strings into individual parameter sets and returns them as an array of Object
+     * arrays. In contrast to JUnitParams, this method does NOT trim parameter values. For example:
+     * <p>
+     * <code>convertParamSets("foo|bar", " baz , bum")</code>
+     * <p>
+     * will return:
+     * <p>
+     * <code>new Object[]{new Object[]{ "foo", "bar"}, new Object[]{" baz ", " bum"}}</code>
+     *
+     * @param paramSets
+     *            the parameter sets, with the parameters separated by '|' or ',' in each set
+     * @return an Object array containing one Object array for each parameter set
+     */
+    public static Object[][] parseParamSets(final String... paramSets)
+    {
+        return Arrays.stream(paramSets).map(JUnitParamsUtils::parseParamSet).toArray(Object[][]::new);
+    }
+
+    /**
+     * Parses the given parameter set string into individual parameters and returns them as an Object array. In contrast
+     * to JUnitParams, this method does NOT trim parameter values.
+     *
+     * @param paramSet
+     *            the parameter set, with the parameters separated by '|' or ','
+     * @return an Object array containing the parameters
+     */
+    static Object[] parseParamSet(final String paramSet)
+    {
+        return StringUtils.splitPreserveAllTokens(paramSet, "|,");
     }
 }

--- a/src/test/java/util/JUnitParamsUtilsTest.java
+++ b/src/test/java/util/JUnitParamsUtilsTest.java
@@ -71,4 +71,57 @@ public class JUnitParamsUtilsTest
         Assert.assertEquals(params[1], wrappedParams[1][0]);
     }
 
+    @Test
+    public void parseParamSet_SingleParam()
+    {
+        final Object[] parsedParams = JUnitParamsUtils.parseParamSet(" abc ");
+
+        Assert.assertEquals(1, parsedParams.length);
+        Assert.assertEquals(" abc ", parsedParams[0]);
+    }
+
+    @Test
+    public void parseParamSet_MultipleParams()
+    {
+        final Object[] parsedParams = JUnitParamsUtils.parseParamSet(" abc,123 ");
+
+        Assert.assertEquals(2, parsedParams.length);
+        Assert.assertEquals(" abc", parsedParams[0]);
+        Assert.assertEquals("123 ", parsedParams[1]);
+    }
+
+    @Test
+    public void parseParamSets_NoParamSet()
+    {
+        final Object[][] parsedParamSets = JUnitParamsUtils.parseParamSets();
+
+        Assert.assertEquals(0, parsedParamSets.length);
+    }
+
+    @Test
+    public void parseParamSets_SingleParamSet()
+    {
+        final Object[][] parsedParamSets = JUnitParamsUtils.parseParamSets("foo|bar");
+
+        Assert.assertEquals(1, parsedParamSets.length);
+        Assert.assertEquals(2, parsedParamSets[0].length);
+        Assert.assertEquals("foo", parsedParamSets[0][0]);
+        Assert.assertEquals("bar", parsedParamSets[0][1]);
+    }
+
+    @Test
+    public void parseParamSets_MultipleParamSets()
+    {
+        final Object[][] parsedParamSets = JUnitParamsUtils.parseParamSets("foo|bar,baz", " 111 , 222|333 ");
+
+        Assert.assertEquals(2, parsedParamSets.length);
+        Assert.assertEquals(3, parsedParamSets[0].length);
+        Assert.assertEquals(3, parsedParamSets[1].length);
+        Assert.assertEquals("foo", parsedParamSets[0][0]);
+        Assert.assertEquals("bar", parsedParamSets[0][1]);
+        Assert.assertEquals("baz", parsedParamSets[0][2]);
+        Assert.assertEquals(" 111 ", parsedParamSets[1][0]);
+        Assert.assertEquals(" 222", parsedParamSets[1][1]);
+        Assert.assertEquals("333 ", parsedParamSets[1][2]);
+    }
 }


### PR DESCRIPTION
* Sanitize values of the passed HtmlUnit cookie for use with OkHttp:
    * domain: must not be empty
    * name: must be non-null and trimmed
    * value: must be non-null and trimmed
    * path: must be non-null and start with "/"
    * expiresAt: don't set if null
* Add unit tests to check correct behavior
* Extended JUnitParamsUtils and added unit tests for it