### PR TITLE
#629: Font issue for dynamic charts

### DIFF
--- a/config/testreport/js/xlt.js
+++ b/config/testreport/js/xlt.js
@@ -618,15 +618,16 @@
                                 borderWidth: 0.5,
                             },
                             textStyle: {
-                                fontFamily: "Roboto",
+                                fontFamily: "sans-serif",
+                                fontWeight: "bold",
+                                color: "#555"
                             },
                             title: {
                                 top: 8,
                                 left: "center",
                                 text: name,
                                 textStyle: {
-                                    fontWeight: 500,
-                                    fontSize: 13,
+                                    fontSize: 13
                                 }
                             },
                             toolbox: {


### PR DESCRIPTION
Use "sans-serif" as the font to use for dynamic charts. Unfortunately, we cannot specify a list of fonts at the chart configuration.