### PR TITLE
#635: WEBP chart images not loading (part 2)

### DIFF
--- a/config/xsl/loadreport/sections/custom-values.xsl
+++ b/config/xsl/loadreport/sections/custom-values.xsl
@@ -151,17 +151,17 @@
                                     <xsl:attribute name="id">chart-<xsl:value-of select="$gid"/></xsl:attribute>
 
                                     <ul class="c-tabs-nav">
-                                        <li class="c-tabs-nav-link c-is-active">
+                                        <li class="c-tabs-nav-link img-tab c-is-active">
                                             <a href="#Overview-{$gid}">Overview</a>
                                         </li>
-                                        <li class="c-tabs-nav-link">
+                                        <li class="c-tabs-nav-link img-tab">
                                             <a href="#Averages-{$gid}">Averages</a>
                                         </li>
                                     </ul>
 
                                     <a href="#tableEntry-{$gid}" class="backlink">Back to Table</a>
 
-                                    <div id="Overview-{$gid}" class="c-tab c-is-active">
+                                    <div id="Overview-{$gid}" class="c-tab img-tab c-is-active">
                                         <div class="c-tab-content chart">
                                             <img>
                                                 <xsl:attribute name="src">charts/customvalues/<xsl:value-of
@@ -173,7 +173,7 @@
                                         </div>
                                     </div>
 
-                                    <div id="Averages-{$gid}" class="c-tab">
+                                    <div id="Averages-{$gid}" class="c-tab img-tab">
                                         <div class="c-tab-content chart">
                                             <img>
                                                 <xsl:attribute name="src">charts/placeholder.webp</xsl:attribute>
@@ -190,11 +190,11 @@
                                     </h3>
                                     <div class="chart">
                                         <h5>Overview</h5>
-                                        <img alt="charts/customvalues/{$encodedChartFilename}.webp"/>
+                                        <img src="charts/customvalues/{$encodedChartFilename}.webp"/>
                                     </div>
                                     <div class="chart">
                                         <h5>Averages</h5>
-                                        <img alt="charts/customvalues/{$encodedChartFilename}_Average.webp"/>
+                                        <img src="charts/customvalues/{$encodedChartFilename}_Average.webp"/>
                                     </div>
                                 </div>
                             </xsl:if>

--- a/config/xsl/loadreport/sections/custom-values.xsl
+++ b/config/xsl/loadreport/sections/custom-values.xsl
@@ -190,11 +190,11 @@
                                     </h3>
                                     <div class="chart">
                                         <h5>Overview</h5>
-                                        <img src="charts/customvalues/{$encodedChartFilename}.webp"/>
+                                        <img alt="charts/customvalues/{$encodedChartFilename}.webp"/>
                                     </div>
                                     <div class="chart">
                                         <h5>Averages</h5>
-                                        <img src="charts/customvalues/{$encodedChartFilename}_Average.webp"/>
+                                        <img alt="charts/customvalues/{$encodedChartFilename}_Average.webp"/>
                                     </div>
                                 </div>
                             </xsl:if>

--- a/config/xsl/loadreport/util/agent-chart.xsl
+++ b/config/xsl/loadreport/util/agent-chart.xsl
@@ -18,13 +18,13 @@
         <div class="chart-group tabs c-tabs no-print" data-name="{name}">
             <xsl:attribute name="id">chart-<xsl:value-of select="$gid"/></xsl:attribute>
             <ul class="c-tabs-nav">
-                <li class="c-tabs-nav-link c-is-active">
+                <li class="c-tabs-nav-link img-tab c-is-active">
                     <a href="#CPU-{$gid}">CPU</a>
                 </li>
-                <li class="c-tabs-nav-link">
+                <li class="c-tabs-nav-link img-tab">
                     <a href="#Memory-{$gid}">Memory</a>
                 </li>
-                <li class="c-tabs-nav-link">
+                <li class="c-tabs-nav-link img-tab">
                     <a href="#Threads-{$gid}">Threads</a>
                 </li>
             </ul>
@@ -35,7 +35,7 @@
                 </xsl:when>
             </xsl:choose>
 
-            <div id="CPU-{$gid}" class="c-tab c-is-active">
+            <div id="CPU-{$gid}" class="c-tab img-tab c-is-active">
                 <div class="c-tab-content chart">
                     <img>
                         <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/CpuUsage.webp</xsl:attribute>
@@ -45,7 +45,7 @@
                 </div>
             </div>
 
-            <div id="Memory-{$gid}" class="c-tab memory">
+            <div id="Memory-{$gid}" class="c-tab img-tab memory">
                 <div class="c-tab-content chart">
                     <img>
                         <xsl:attribute name="src">charts/placeholder.webp</xsl:attribute>
@@ -54,7 +54,7 @@
                 </div>
             </div>
 
-            <div id="Threads-{$gid}" class="c-tab">
+            <div id="Threads-{$gid}" class="c-tab img-tab">
                 <div class="c-tab-content chart">
                     <img>
                         <xsl:attribute name="src">charts/placeholder.webp</xsl:attribute>
@@ -68,19 +68,19 @@
             <div class="chart">
                 <h5>Memory</h5>
                 <img>
-                    <xsl:attribute name="alt">charts/agents/<xsl:value-of select="$directory"/>/MemoryUsage.webp</xsl:attribute>
+                    <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/MemoryUsage.webp</xsl:attribute>
                 </img>
             </div>
 
             <div class="chart">
                 <h5>CPU</h5>
                 <img>
-                    <xsl:attribute name="alt">charts/agents/<xsl:value-of select="$directory"/>/CpuUsage.webp</xsl:attribute>
+                    <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/CpuUsage.webp</xsl:attribute>
                 </img>
 
                 <h5>Threads</h5>
                 <img>
-                    <xsl:attribute name="alt">charts/agents/<xsl:value-of select="$directory"/>/Threads.webp</xsl:attribute>
+                    <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/Threads.webp</xsl:attribute>
                 </img>
             </div>
         </div>

--- a/config/xsl/loadreport/util/agent-chart.xsl
+++ b/config/xsl/loadreport/util/agent-chart.xsl
@@ -68,19 +68,19 @@
             <div class="chart">
                 <h5>Memory</h5>
                 <img>
-                    <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/MemoryUsage.webp</xsl:attribute>
+                    <xsl:attribute name="alt">charts/agents/<xsl:value-of select="$directory"/>/MemoryUsage.webp</xsl:attribute>
                 </img>
             </div>
 
             <div class="chart">
                 <h5>CPU</h5>
                 <img>
-                    <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/CpuUsage.webp</xsl:attribute>
+                    <xsl:attribute name="alt">charts/agents/<xsl:value-of select="$directory"/>/CpuUsage.webp</xsl:attribute>
                 </img>
 
                 <h5>Threads</h5>
                 <img>
-                    <xsl:attribute name="src">charts/agents/<xsl:value-of select="$directory"/>/Threads.webp</xsl:attribute>
+                    <xsl:attribute name="alt">charts/agents/<xsl:value-of select="$directory"/>/Threads.webp</xsl:attribute>
                 </img>
             </div>
         </div>

--- a/config/xsl/loadreport/util/timer-chart.xsl
+++ b/config/xsl/loadreport/util/timer-chart.xsl
@@ -158,44 +158,44 @@
                 <xsl:when test="$type = 'transaction'">
                     <div class="chart">
                         <h5>Overview</h5>
-                        <img alt="charts/{$directory}/{$encodedName}.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}.webp"/>
 
                         <h5>Averages</h5>
-                        <img alt="charts/{$directory}/{$encodedName}_Average.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}_Average.webp"/>
                     </div>
 
                     <div class="chart">
                         <h5>Count/s</h5>
-                        <img alt="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
 
                         <h5>Arrival Rate</h5>
-                        <img alt="charts/{$directory}/{$encodedName}_ArrivalRate.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}_ArrivalRate.webp"/>
 
                         <h5>Concurrent Users</h5>
-                        <img alt="charts/{$directory}/{$encodedName}_ConcurrentUsers.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}_ConcurrentUsers.webp"/>
                     </div>
                 </xsl:when>
                 <xsl:otherwise>
                     <div class="chart">
                         <h5>Overview</h5>
-                        <img alt="charts/{$directory}/{$encodedName}.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}.webp"/>
                     </div>
                     <div class="chart">
                         <h5>Count/s</h5>
-                        <img alt="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
                     </div>
                     <div class="chart">
                         <h5>Averages</h5>
-                        <img alt="charts/{$directory}/{$encodedName}_Average.webp"/>
+                        <img src="charts/{$directory}/{$encodedName}_Average.webp"/>
                     </div>
                     <xsl:if test="$type = 'request'">
                         <div class="chart">
                             <h5>Response Size</h5>
-                            <img alt="charts/{$directory}/{$encodedName}_ResponseSize.webp"/>
+                            <img src="charts/{$directory}/{$encodedName}_ResponseSize.webp"/>
                         </div>
                         <div class="chart">
                             <h5>Distribution</h5>
-                            <img alt="charts/{$directory}/{$encodedName}_Histogram.webp"/>
+                            <img src="charts/{$directory}/{$encodedName}_Histogram.webp"/>
                         </div>
                     </xsl:if>
                 </xsl:otherwise>

--- a/config/xsl/loadreport/util/timer-chart.xsl
+++ b/config/xsl/loadreport/util/timer-chart.xsl
@@ -158,44 +158,44 @@
                 <xsl:when test="$type = 'transaction'">
                     <div class="chart">
                         <h5>Overview</h5>
-                        <img src="charts/{$directory}/{$encodedName}.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}.webp"/>
 
                         <h5>Averages</h5>
-                        <img src="charts/{$directory}/{$encodedName}_Average.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}_Average.webp"/>
                     </div>
 
                     <div class="chart">
                         <h5>Count/s</h5>
-                        <img src="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
 
                         <h5>Arrival Rate</h5>
-                        <img src="charts/{$directory}/{$encodedName}_ArrivalRate.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}_ArrivalRate.webp"/>
 
                         <h5>Concurrent Users</h5>
-                        <img src="charts/{$directory}/{$encodedName}_ConcurrentUsers.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}_ConcurrentUsers.webp"/>
                     </div>
                 </xsl:when>
                 <xsl:otherwise>
                     <div class="chart">
                         <h5>Overview</h5>
-                        <img src="charts/{$directory}/{$encodedName}.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}.webp"/>
                     </div>
                     <div class="chart">
                         <h5>Count/s</h5>
-                        <img src="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}_CountPerSecond.webp"/>
                     </div>
                     <div class="chart">
                         <h5>Averages</h5>
-                        <img src="charts/{$directory}/{$encodedName}_Average.webp"/>
+                        <img alt="charts/{$directory}/{$encodedName}_Average.webp"/>
                     </div>
                     <xsl:if test="$type = 'request'">
                         <div class="chart">
                             <h5>Response Size</h5>
-                            <img src="charts/{$directory}/{$encodedName}_ResponseSize.webp"/>
+                            <img alt="charts/{$directory}/{$encodedName}_ResponseSize.webp"/>
                         </div>
                         <div class="chart">
                             <h5>Distribution</h5>
-                            <img src="charts/{$directory}/{$encodedName}_Histogram.webp"/>
+                            <img alt="charts/{$directory}/{$encodedName}_Histogram.webp"/>
                         </div>
                     </xsl:if>
                 </xsl:otherwise>


### PR DESCRIPTION
Mark all chart image tabs on the Custom Data and Agents page with the "img-tab" class as well.