### PR TITLE
#633: Dynamic charts: Use the configured time zone instead of UTC

### DIFF
--- a/config/testreport/js/xlt.js
+++ b/config/testreport/js/xlt.js
@@ -570,6 +570,8 @@
             function initAndLoadEChart(echartDiv) {
                 var name = echartDiv.getAttribute('name');
                 var url = echartDiv.getAttribute('src');
+                const timeZoneLabel = echartDiv.getAttribute('data-timezone-label');
+                const timeZoneOffset = parseInt(echartDiv.getAttribute('data-timezone-offset'));
 
                 // create an initially empty echart
                 var echart = echarts.init(echartDiv);
@@ -593,17 +595,22 @@
                         var dataMaxMinDiff = [];
 
                         for (var item of data) {
+                            // shift time values by timezone offset
+                            const shiftedTime = item[0] + timeZoneOffset;
                             // timestamp and mean value
-                            dataMean.push([item[0], item[1]]);
+                            dataMean.push([shiftedTime, item[1]]);
                             // timestamp and min value
-                            dataMinimum.push([item[0], item[2]]);
+                            dataMinimum.push([shiftedTime, item[2]]);
                             // timestamp and max value
-                            dataMaximum.push([item[0], item[3]]);
+                            dataMaximum.push([shiftedTime, item[3]]);
                             // timestamp and diff value
-                            dataMaxMinDiff.push([item[0], item[3] - item[2]]);
+                            dataMaxMinDiff.push([shiftedTime, item[3] - item[2]]);
                         }
 
                         // set up the chart
+                        // note: echarts doesn't support setting a custom time zone (only UTC or the local time zone);
+                        // as a hack to work around that, we set the "useUTC" flag but label the time axis with the
+                        // intended time zone's name and shift the UTC time values by the intended time zone's offset
                         echart.setOption({
                             animation: false,
                             backgroundColor: "#fafafa",
@@ -674,7 +681,7 @@
                             useUTC: true,
                             xAxis: {
                                 type: "time",
-                                name: "Time [UTC]",
+                                name: "Time [" + timeZoneLabel + "]",
                                 nameLocation: "center",
                                 nameGap: 24,
                                 axisLine: {

--- a/config/xsl/loadreport/util/timer-chart.xsl
+++ b/config/xsl/loadreport/util/timer-chart.xsl
@@ -18,11 +18,11 @@
         </xsl:variable>
 
         <xsl:variable name="timeZoneLabel">
-            <xsl:value-of select="/testreport/general/timeZoneLabel"/>
+            <xsl:value-of select="/testreport/configuration/reportGeneratorConfiguration/timeZoneLabel"/>
         </xsl:variable>
 
         <xsl:variable name="timeZoneOffset">
-            <xsl:value-of select="/testreport/general/timeZoneOffset"/>
+            <xsl:value-of select="/testreport/configuration/reportGeneratorConfiguration/timeZoneOffset"/>
         </xsl:variable>
 
         <a>

--- a/config/xsl/loadreport/util/timer-chart.xsl
+++ b/config/xsl/loadreport/util/timer-chart.xsl
@@ -17,6 +17,14 @@
             <xsl:value-of select="/testreport/configuration/reportGeneratorConfiguration/dynamicChartsEnabled"/>
         </xsl:variable>
 
+        <xsl:variable name="timeZoneLabel">
+            <xsl:value-of select="/testreport/general/timeZoneLabel"/>
+        </xsl:variable>
+
+        <xsl:variable name="timeZoneOffset">
+            <xsl:value-of select="/testreport/general/timeZoneOffset"/>
+        </xsl:variable>
+
         <a>
             <xsl:attribute name="id"><xsl:value-of select="name"/></xsl:attribute>
             <xsl:comment>
@@ -82,6 +90,12 @@
                         <xsl:attribute name="src">charts/<xsl:value-of select="$directory"/>/<xsl:value-of
                             select="$encodedName"/>.json</xsl:attribute>
                         <xsl:attribute name="name"><xsl:value-of select="name"/></xsl:attribute>
+                        <xsl:attribute name="data-timezone-label">
+                            <xsl:value-of select="$timeZoneLabel"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="data-timezone-offset">
+                            <xsl:value-of select="$timeZoneOffset"/>
+                        </xsl:attribute>
                     </div>
                 </div>
             </xsl:if>

--- a/src/main/java/com/xceptance/xlt/report/providers/GeneralReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/GeneralReport.java
@@ -16,7 +16,6 @@
 package com.xceptance.xlt.report.providers;
 
 import java.util.Date;
-import java.util.List;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -52,4 +51,14 @@ public class GeneralReport
      * The total run time of the test.
      */
     public int duration;
+
+    /**
+     * The display label of the time zone used for report creation.
+     */
+    public String timeZoneLabel;
+
+    /**
+     * The offset of the time zone used for report creation compared to UTC (in milliseconds).
+     */
+    public int timeZoneOffset;
 }

--- a/src/main/java/com/xceptance/xlt/report/providers/GeneralReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/GeneralReport.java
@@ -51,14 +51,4 @@ public class GeneralReport
      * The total run time of the test.
      */
     public int duration;
-
-    /**
-     * The display label of the time zone used for report creation.
-     */
-    public String timeZoneLabel;
-
-    /**
-     * The offset of the time zone used for report creation compared to UTC (in milliseconds).
-     */
-    public int timeZoneOffset;
 }

--- a/src/main/java/com/xceptance/xlt/report/providers/GeneralReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/GeneralReportProvider.java
@@ -17,8 +17,6 @@ package com.xceptance.xlt.report.providers;
 
 import java.io.File;
 import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
@@ -176,10 +174,6 @@ public class GeneralReportProvider extends AbstractReportProvider
         report.hits = totalRequests;
         report.bytesSent = totalBytesSent;
         report.bytesReceived = totalBytesReceived;
-
-        final TimeZone tz = TimeZone.getDefault();
-        report.timeZoneLabel = tz.getDisplayName(tz.inDaylightTime(report.startTime), TimeZone.SHORT, Locale.US);
-        report.timeZoneOffset = tz.getOffset(testStartTime);
 
         return report;
     }

--- a/src/main/java/com/xceptance/xlt/report/providers/GeneralReportProvider.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/GeneralReportProvider.java
@@ -17,6 +17,8 @@ package com.xceptance.xlt.report.providers;
 
 import java.io.File;
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
@@ -174,6 +176,10 @@ public class GeneralReportProvider extends AbstractReportProvider
         report.hits = totalRequests;
         report.bytesSent = totalBytesSent;
         report.bytesReceived = totalBytesReceived;
+
+        final TimeZone tz = TimeZone.getDefault();
+        report.timeZoneLabel = tz.getDisplayName(tz.inDaylightTime(report.startTime), TimeZone.SHORT, Locale.US);
+        report.timeZoneOffset = tz.getOffset(testStartTime);
 
         return report;
     }

--- a/src/main/java/com/xceptance/xlt/report/providers/ReportGeneratorConfigurationReport.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/ReportGeneratorConfigurationReport.java
@@ -18,6 +18,10 @@ package com.xceptance.xlt.report.providers;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.xceptance.xlt.report.ReportGeneratorConfiguration;
 
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
 /**
  * Represents report generator configuration values that were used during report creation and should be shown in the
  * report.
@@ -25,15 +29,40 @@ import com.xceptance.xlt.report.ReportGeneratorConfiguration;
 @XStreamAlias("reportGeneratorConfiguration")
 public class ReportGeneratorConfigurationReport
 {
+    /**
+     * The number of requests per bucket in the "Slowest Requests" report.
+     */
     public int slowestRequestsPerBucket;
 
+    /**
+     * The total number of requests in the "Slowest Requests" report.
+     */
     public int slowestRequestsTotal;
 
+    /**
+     * The minimum runtime of requests in the "Slowest Requests" report.
+     */
     public int slowestRequestsMinRuntime;
 
+    /**
+     * The maximum runtime of requests in the "Slowest Requests" report.
+     */
     public int slowestRequestsMaxRuntime;
 
+    /**
+     * Indicates if dynamic charts are enabled in the report.
+     */
     public boolean dynamicChartsEnabled;
+
+    /**
+     * The display label of the time zone used for report creation.
+     */
+    public String timeZoneLabel;
+
+    /**
+     * The offset of the time zone used for report creation compared to UTC (in milliseconds).
+     */
+    public int timeZoneOffset;
 
     ReportGeneratorConfigurationReport(ReportGeneratorConfiguration config)
     {
@@ -42,5 +71,9 @@ public class ReportGeneratorConfigurationReport
         this.slowestRequestsMinRuntime = config.getSlowestRequestsMinRuntime();
         this.slowestRequestsMaxRuntime = config.getSlowestRequestsMaxRuntime();
         this.dynamicChartsEnabled = config.dynamicChartsEnabled();
+
+        final TimeZone tz = TimeZone.getDefault();
+        timeZoneLabel = tz.getDisplayName(tz.inDaylightTime(new Date(config.getChartStartTime())), TimeZone.SHORT, Locale.US);
+        timeZoneOffset = tz.getOffset(config.getChartStartTime());
     }
 }


### PR DESCRIPTION
See: https://github.com/Xceptance/XLT/issues/633