### PR TITLE
#495: Allow smaller than 1% for moving average settings

### DIFF
--- a/config/reportgenerator.properties
+++ b/config/reportgenerator.properties
@@ -118,8 +118,9 @@ com.xceptance.xlt.reportgenerator.charts.height = 300
 
 #com.xceptance.xlt.reportgenerator.charts.cappingMode = always
 
-## The percentage of values taken when calculating the moving average series.
-com.xceptance.xlt.reportgenerator.charts.movingAverage.percentageOfValues = 5
+## The percentage of values taken when calculating the moving average series
+## (default: 5.0).
+com.xceptance.xlt.reportgenerator.charts.movingAverage.percentageOfValues = 5.0
 
 ## Whether dynamic/interactive charts are enabled in addition to the regular
 ## WEBP image charts (default: true).

--- a/doc/internal-doc/api.sig
+++ b/doc/internal-doc/api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.2.0-SNAPSHOT
+#Version 9.2.2
 
 CLSS public abstract com.xceptance.xlt.api.actions.AbstractAction
 cons protected init(com.xceptance.xlt.api.actions.AbstractAction,java.lang.String)
@@ -1666,9 +1666,9 @@ meth public boolean wantsDataRecords()
 
 CLSS public abstract interface com.xceptance.xlt.api.report.ReportProviderConfiguration
 meth public abstract boolean shouldChartsGenerated()
+meth public abstract double getMovingAveragePercentage()
 meth public abstract int getChartHeight()
 meth public abstract int getChartWidth()
-meth public abstract int getMovingAveragePercentage()
 meth public abstract java.io.File getChartDirectory()
 meth public abstract java.io.File getCsvDirectory()
 meth public abstract java.io.File getReportDirectory()

--- a/src/main/java/com/xceptance/xlt/api/report/ReportProviderConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/api/report/ReportProviderConfiguration.java
@@ -86,7 +86,7 @@ public interface ReportProviderConfiguration
      * 
      * @return the percentage
      */
-    public int getMovingAveragePercentage();
+    public double getMovingAveragePercentage();
 
     /**
      * Returns all the settings from the file "xlt/config/reportgenerator.properties" as raw properties. Use these

--- a/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
+++ b/src/main/java/com/xceptance/xlt/report/ReportGeneratorConfiguration.java
@@ -237,7 +237,7 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
 
     private final File homeDirectory;
 
-    private final int movingAveragePoints;
+    private final double movingAveragePoints;
 
     private final List<String> outputFileNames;
 
@@ -491,7 +491,7 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
         chartsCompressionFactor = (float) getDoubleProperty(PROP_CHARTS_COMPRESSION_FACTOR, 0.0f);
         chartsWidth = getIntProperty(PROP_CHARTS_WIDTH, 900);
         chartsHeight = getIntProperty(PROP_CHARTS_HEIGHT, 300);
-        movingAveragePoints = getIntProperty(PROP_CHARTS_MOV_AVG_PERCENTAGE, 5);
+        movingAveragePoints = getDoubleProperty(PROP_CHARTS_MOV_AVG_PERCENTAGE, 5.0);
 
         dynamicChartsEnabled = getBooleanProperty(PROP_DYNAMIC_CHARTS_ENABLED, true);
 
@@ -767,7 +767,7 @@ public class ReportGeneratorConfiguration extends AbstractConfiguration implemen
      * {@inheritDoc}
      */
     @Override
-    public int getMovingAveragePercentage()
+    public double getMovingAveragePercentage()
     {
         return movingAveragePoints;
     }

--- a/src/main/java/com/xceptance/xlt/report/providers/AbstractDataProcessor.java
+++ b/src/main/java/com/xceptance/xlt/report/providers/AbstractDataProcessor.java
@@ -36,7 +36,7 @@ public abstract class AbstractDataProcessor
 
     private File csvDir;
 
-    private int movingAveragePercentage;
+    private double movingAveragePercentage;
 
     private ChartCappingInfo chartCappingInfo;
 
@@ -140,7 +140,7 @@ public abstract class AbstractDataProcessor
      * 
      * @return the value of movingAveragePercentage
      */
-    public int getMovingAveragePercentage()
+    public double getMovingAveragePercentage()
     {
         return movingAveragePercentage;
     }
@@ -248,7 +248,7 @@ public abstract class AbstractDataProcessor
      * @param movingAveragePercentage
      *            the new movingAveragePercentage value
      */
-    public void setMovingAveragePercentage(final int movingAveragePercentage)
+    public void setMovingAveragePercentage(final double movingAveragePercentage)
     {
         this.movingAveragePercentage = movingAveragePercentage;
     }

--- a/src/main/java/com/xceptance/xlt/report/util/JFreeChartUtils.java
+++ b/src/main/java/com/xceptance/xlt/report/util/JFreeChartUtils.java
@@ -164,14 +164,14 @@ public final class JFreeChartUtils
      */
     public enum MoreColors
     {
-     BROWN(0xB97A57),
-     GRAY(0xAAAAAA),
-     GREEN(0x00AA00),
-     LIGHT_GRAY(0x757575),
-     LIGHT_GREEN(0xB5E61D),
-     LILAC(0xC8BFE7),
-     ORANGE(0xFF9900),
-     STEEL_BLUE(0x7092BE);
+        BROWN(0xB97A57),
+        GRAY(0xAAAAAA),
+        GREEN(0x00AA00),
+        LIGHT_GRAY(0x757575),
+        LIGHT_GREEN(0xB5E61D),
+        LILAC(0xC8BFE7),
+        ORANGE(0xFF9900),
+        STEEL_BLUE(0x7092BE);
 
         private final Color color;
 
@@ -672,7 +672,7 @@ public final class JFreeChartUtils
      */
     public static JFreeChart createLineChart(final String chartTitle, final String rangeAxisTitle, final TimeSeries series,
                                              final long startTime, final long endTime, final boolean includeMovingAverage,
-                                             final int percentage)
+                                             final double percentage)
     {
         return createLineChart(chartTitle, rangeAxisTitle, series, startTime, endTime, includeMovingAverage, percentage, true);
     }
@@ -700,7 +700,7 @@ public final class JFreeChartUtils
      */
     public static JFreeChart createLineChart(final String chartTitle, final String rangeAxisTitle, final TimeSeries series,
                                              final long startTime, final long endTime, final boolean includeMovingAverage,
-                                             final int percentage, final boolean showDots)
+                                             final double percentage, final boolean showDots)
     {
         final TimeSeries movingAverageSeries = includeMovingAverage ? createMovingAverageTimeSeries(series, percentage) : null;
 
@@ -934,10 +934,10 @@ public final class JFreeChartUtils
      *            the percentaged amount of values for building the moving average
      * @return the time series
      */
-    public static TimeSeries createMovingAverageTimeSeries(final TimeSeries series, final int percentage)
+    public static TimeSeries createMovingAverageTimeSeries(final TimeSeries series, final double percentage)
     {
         // take the last X percent of the values
-        final int samples = Math.max(2, series.getItemCount() * percentage / 100);
+        final int samples = Math.max(2, (int) (series.getItemCount() * percentage / 100.0));
 
         // derive the name from the source series
         final String avgSeriesName = series.getKey() + " (Moving Average)";

--- a/src/test/java/com/xceptance/xlt/report/providers/DummyReportProviderConfiguration.java
+++ b/src/test/java/com/xceptance/xlt/report/providers/DummyReportProviderConfiguration.java
@@ -84,7 +84,7 @@ class DummyReportProviderConfiguration implements ReportProviderConfiguration
     }
 
     @Override
-    public int getMovingAveragePercentage()
+    public double getMovingAveragePercentage()
     {
         return 0;
     }


### PR DESCRIPTION
Use double for the moving average percentage report generator setting.