### PR TITLE
#649: Remove usage of FirefoxBinary

### DIFF
--- a/doc/internal-doc/api.sig
+++ b/doc/internal-doc/api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.2.0-SNAPSHOT
+#Version 9.2.2
 
 CLSS public abstract com.xceptance.xlt.api.actions.AbstractAction
 cons protected init(com.xceptance.xlt.api.actions.AbstractAction,java.lang.String)
@@ -2094,11 +2094,10 @@ CLSS public final static com.xceptance.xlt.api.webdriver.XltFirefoxDriver$Builde
  outer com.xceptance.xlt.api.webdriver.XltFirefoxDriver
 cons public init()
 meth public com.xceptance.xlt.api.webdriver.XltFirefoxDriver build()
-meth public com.xceptance.xlt.api.webdriver.XltFirefoxDriver$Builder setBinary(org.openqa.selenium.firefox.FirefoxBinary)
 meth public com.xceptance.xlt.api.webdriver.XltFirefoxDriver$Builder setHeadless(boolean)
-meth public com.xceptance.xlt.api.webdriver.XltFirefoxDriver$Builder setProfile(org.openqa.selenium.firefox.FirefoxProfile)
+meth public com.xceptance.xlt.api.webdriver.XltFirefoxDriver$Builder setOptions(org.openqa.selenium.firefox.FirefoxOptions)
 supr java.lang.Object
-hfds binary,headless,options,profile
+hfds headless,options
 
 CLSS public com.xceptance.xlt.engine.xltdriver.HtmlUnitDriver
 cons protected init(org.htmlunit.BrowserVersion)

--- a/src/main/java/com/xceptance/xlt/api/webdriver/XltFirefoxDriver.java
+++ b/src/main/java/com/xceptance/xlt/api/webdriver/XltFirefoxDriver.java
@@ -25,7 +25,6 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.firefox.FileExtension;
-import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
@@ -531,37 +530,20 @@ public final class XltFirefoxDriver extends FirefoxDriver
      */
     public static final class Builder
     {
-        private FirefoxBinary binary;
-
-        private FirefoxProfile profile;
+        private FirefoxOptions options;
 
         private boolean headless = HEADLESS_ENABLED;
 
-        private FirefoxOptions options;
-
         /**
-         * Sets the desired binary and clears the GeckoDriver service setting.
+         * Sets the desired options.
          *
-         * @param binary
-         *            the binary
+         * @param options
+         *            the options
          * @return this builder instance
          */
-        public Builder setBinary(final FirefoxBinary binary)
+        public Builder setOptions(final FirefoxOptions options)
         {
-            this.binary = binary;
-            return this;
-        }
-
-        /**
-         * Sets the desired profile.
-         *
-         * @param profile
-         *            the profile
-         * @return this builder instance
-         */
-        public Builder setProfile(final FirefoxProfile profile)
-        {
-            this.profile = profile;
+            this.options = options;
             return this;
         }
 
@@ -585,17 +567,7 @@ public final class XltFirefoxDriver extends FirefoxDriver
          */
         public XltFirefoxDriver build()
         {
-            final FirefoxOptions opts = ObjectUtils.defaultIfNull(this.options, new FirefoxOptions());
-            if (binary != null)
-            {
-                opts.setBinary(binary);
-            }
-            if (profile != null)
-            {
-                opts.setProfile(profile);
-            }
-
-            return new XltFirefoxDriver(opts, headless);
+            return new XltFirefoxDriver(options, headless);
         }
     }
 }


### PR DESCRIPTION
In XltFirefoxDriver.Builder:

* Add the option to pass a FirefoxOptions object.
* Remove the option to pass a FirefoxProfile object. A Firefox profile can be set at the FirefoxOptions object if needed.
* Remove the option to pass a FirefoxBinary object (deprecated). Again, the path to a Firefox binary can be set at the FirefoxOptions object if needed.