### PR TITLE
 Failed to upload huge test suites to private machines

### DIFF
--- a/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/StreamingWebSocket.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/StreamingWebSocket.java
@@ -23,7 +23,8 @@ import java.io.PipedOutputStream;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 
-import org.java_websocket.WebSocket;
+import org.apache.commons.io.IOUtils;
+import org.java_websocket.WebSocketImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class StreamingWebSocket
 {
     private static final Logger log = LoggerFactory.getLogger(StreamingWebSocket.class);
 
-    private final StreamingWebSocketClient streamingWebSocketClient;
+    private final WebSocketImpl webSocket;
 
     private final PipedOutputStream pipeOut;
 
@@ -47,25 +48,24 @@ public class StreamingWebSocket
 
     private boolean outputShutDown;
 
-    StreamingWebSocket(final StreamingWebSocketClient streamingWebSocketClient) throws IOException
+    StreamingWebSocket(final WebSocketImpl webSocket) throws IOException
     {
-        this.streamingWebSocketClient = streamingWebSocketClient;
-
+        this.webSocket = webSocket;
+        
         pipeOut = new PipedOutputStream();
         in = new PipedInputStream(pipeOut);
-        out = new WebSocketOutputStream(streamingWebSocketClient);
+        out = new WebSocketOutputStream(webSocket);
     }
 
-    @Override
-    public void close() throws IOException
+    public void close()
     {
-        try
+        IOUtils.closeQuietly(pipeOut);
+        IOUtils.closeQuietly(in);
+        IOUtils.closeQuietly(out);
+
+        if (!webSocket.isClosed())
         {
-            streamingWebSocketClient.closeBlocking();
-        }
-        catch (final InterruptedException ex)
-        {
-            throw new IOException("Interrupted while closing underlying web socket", ex);
+            webSocket.close();
         }
     }
 
@@ -92,7 +92,7 @@ public class StreamingWebSocket
         if (!outputShutDown)
         {
             // send an empty data array to indicate EOF
-            streamingWebSocketClient.send(new byte[0]);
+            out.write(new byte[0]);
             outputShutDown = true;
         }
     }
@@ -107,7 +107,7 @@ public class StreamingWebSocket
             if (data.length == 0)
             {
                 // an empty data array indicates EOF
-                pipeOut.close();
+                IOUtils.closeQuietly(pipeOut);
             }
             else
             {
@@ -118,45 +118,6 @@ public class StreamingWebSocket
         catch (final IOException e)
         {
             log.error("Error piping data to input stream", e);
-        }
-    }
-
-    void handleClose()
-    {
-        try
-        {
-            pipeOut.close();
-        }
-        catch (final IOException ignored)
-        {
-        }
-    }
-
-    /**
-     * Sends bytes written to this output stream as binary messages to the wrapped web socket.
-     */
-    private static class WebSocketOutputStream extends OutputStream
-    {
-        private final WebSocket webSocket;
-
-        public WebSocketOutputStream(final WebSocket webSocket)
-        {
-            this.webSocket = webSocket;
-        }
-
-        @Override
-        public void write(final int b) throws IOException
-        {
-            webSocket.send(new byte[]
-                {
-                    (byte) b
-                });
-        }
-
-        @Override
-        public void write(final byte[] b, final int off, final int len)
-        {
-            webSocket.send(ByteBuffer.wrap(b, off, len));
         }
     }
 }

--- a/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/StreamingWebSocketClient.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/StreamingWebSocketClient.java
@@ -52,9 +52,6 @@ public class StreamingWebSocketClient extends WebSocketClient
 
         setSocketFactory(sslSocketFactory);
 
-        // disable sending out ping frames and waiting for pongs (the relay will control this)
-        setConnectionLostTimeout(0);
-
         final WebSocketImpl webSocketImpl = ReflectionUtils.readInstanceField(this, "engine");
         socket = new StreamingWebSocket(webSocketImpl);
 
@@ -111,18 +108,24 @@ public class StreamingWebSocketClient extends WebSocketClient
     }
 
     @Override
-    public void onWebsocketPing(WebSocket conn, Framedata f)
+    public void onWebsocketPing(final WebSocket webSocket, final Framedata f)
     {
-        super.onWebsocketPing(conn, f);
+        super.onWebsocketPing(webSocket, f);
 
-        log.trace("Ping received");
+        if (log.isTraceEnabled())
+        {
+            log.trace("Received ping from '{}'", webSocket.getRemoteSocketAddress().getHostString());
+        }
     }
 
     @Override
-    public void onWebsocketPong(WebSocket conn, Framedata f)
+    public void onWebsocketPong(final WebSocket webSocket, final Framedata f)
     {
-        super.onWebsocketPong(conn, f);
+        super.onWebsocketPong(webSocket, f);
 
-        log.trace("Pong received");
+        if (log.isTraceEnabled())
+        {
+            log.trace("Received pong from '{}'", webSocket.getRemoteSocketAddress().getHostString());
+        }
     }
 }

--- a/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/StreamingWebSocketClient.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/StreamingWebSocketClient.java
@@ -22,10 +22,16 @@ import java.nio.ByteBuffer;
 
 import javax.net.ssl.SSLSocketFactory;
 
+import org.java_websocket.WebSocket;
+import org.java_websocket.WebSocketImpl;
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.framing.CloseFrame;
+import org.java_websocket.framing.Framedata;
 import org.java_websocket.handshake.ServerHandshake;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.xceptance.common.lang.ReflectionUtils;
 
 /**
  * A {@link WebSocketClient} that opens a standard web socket connection, but exposes it as a {@link StreamingWebSocket}
@@ -37,6 +43,8 @@ public class StreamingWebSocketClient extends WebSocketClient
 
     private final StreamingWebSocket socket;
 
+    private int framesReceived;
+
     public StreamingWebSocketClient(final String host, final int port, final SSLSocketFactory sslSocketFactory)
         throws URISyntaxException, IOException, InterruptedException
     {
@@ -44,7 +52,11 @@ public class StreamingWebSocketClient extends WebSocketClient
 
         setSocketFactory(sslSocketFactory);
 
-        socket = new StreamingWebSocket(this);
+        // disable sending out ping frames and waiting for pongs (the relay will control this)
+        setConnectionLostTimeout(0);
+
+        final WebSocketImpl webSocketImpl = ReflectionUtils.readInstanceField(this, "engine");
+        socket = new StreamingWebSocket(webSocketImpl);
 
         connectBlocking();
     }
@@ -57,13 +69,14 @@ public class StreamingWebSocketClient extends WebSocketClient
     @Override
     public void onOpen(final ServerHandshake handshakedata)
     {
-        log.debug("Web socket opened");
+        log.trace("Web socket opened");
     }
 
     @Override
     public void onMessage(final ByteBuffer bytes)
     {
-        log.debug("Received binary message with {} bytes", bytes.remaining());
+        framesReceived++;
+        log.trace("Received binary message: frame #{} with {} bytes", framesReceived, bytes.remaining());
 
         socket.handleIncomingData(bytes);
     }
@@ -71,7 +84,7 @@ public class StreamingWebSocketClient extends WebSocketClient
     @Override
     public void onMessage(final String message)
     {
-        log.debug("Received text message: {}", message);
+        log.trace("Received text message: {}", message);
 
         throw new UnsupportedOperationException("Unexpected text message received: " + message);
     }
@@ -79,14 +92,37 @@ public class StreamingWebSocketClient extends WebSocketClient
     @Override
     public void onClose(final int code, final String reason, final boolean remote)
     {
-        log.debug("Web socket closed (code: {}, reason: {}, remote: {})", code, reason, remote);
+        if (code == CloseFrame.NORMAL)
+        {
+            log.trace("Web socket closed normally (code: {}, reason: '{}', remote: {})", code, reason, remote);
+        }
+        else
+        {
+            log.error("Web socket closed due to issues (code: {}, reason: '{}', remote: {})", code, reason, remote);
+        }
 
-        socket.handleClose();
+        socket.close();
     }
 
     @Override
     public void onError(final Exception ex)
     {
-        log.error("Websocket error: {}", ex.toString());
+        log.error("Web socket error: {}", ex.toString());
+    }
+
+    @Override
+    public void onWebsocketPing(WebSocket conn, Framedata f)
+    {
+        super.onWebsocketPing(conn, f);
+
+        log.trace("Ping received");
+    }
+
+    @Override
+    public void onWebsocketPong(WebSocket conn, Framedata f)
+    {
+        super.onWebsocketPong(conn, f);
+
+        log.trace("Pong received");
     }
 }

--- a/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/WebSocketOutputStream.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/WebSocketOutputStream.java
@@ -28,6 +28,12 @@ import org.slf4j.LoggerFactory;
  */
 class WebSocketOutputStream extends OutputStream
 {
+    /**
+     * The maximum number of frames in the web socket out queue. New data frames can be placed in the queue only if the
+     * current queue size is lower. This way we allow ping/pong control frames to slip in and be sent out in time.
+     */
+    private static final int BACKPRESSURE_THRESHOLD = 50;
+
     static final Logger log = LoggerFactory.getLogger(WebSocketOutputStream.class);
 
     private final WebSocketImpl webSocket;
@@ -78,7 +84,7 @@ class WebSocketOutputStream extends OutputStream
     @Override
     public void write(final byte[] b, final int off, final int len)
     {
-        while (webSocket.outQueue.size() > 50)
+        while (webSocket.outQueue.size() >= BACKPRESSURE_THRESHOLD)
         {
             sleep(10L);
         }
@@ -95,7 +101,7 @@ class WebSocketOutputStream extends OutputStream
     {
         try
         {
-            Thread.sleep(10);
+            Thread.sleep(millis);
         }
         catch (final InterruptedException ex)
         {

--- a/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/WebSocketOutputStream.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/WebSocketOutputStream.java
@@ -44,7 +44,7 @@ class WebSocketOutputStream extends OutputStream
     @Override
     public void close() throws IOException
     {
-        log.debug("Closing web socket output stream: {} frames/{} bytes sent", framesSent, bytesSent);
+        log.trace("Closing web socket output stream: {} frames/{} bytes sent", framesSent, bytesSent);
     }
 
     @Override
@@ -53,7 +53,7 @@ class WebSocketOutputStream extends OutputStream
         int queueSize;
         while ((queueSize = webSocket.outQueue.size()) > 0)
         {
-            log.debug("Flushing web socket output stream: {} frames left", queueSize);
+            log.trace("Flushing web socket output stream: {} frames left", queueSize);
             sleep(10L);
         }
 

--- a/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/WebSocketOutputStream.java
+++ b/src/main/java/com/xceptance/xlt/agentcontroller/xtc/ws/WebSocketOutputStream.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2005-2026 Xceptance Software Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xceptance.xlt.agentcontroller.xtc.ws;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import org.java_websocket.WebSocketImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sends bytes written to this output stream as binary messages to the wrapped web socket.
+ */
+class WebSocketOutputStream extends OutputStream
+{
+    static final Logger log = LoggerFactory.getLogger(WebSocketOutputStream.class);
+
+    private final WebSocketImpl webSocket;
+
+    private int framesSent;
+
+    private long bytesSent;
+
+    public WebSocketOutputStream(final WebSocketImpl webSocket)
+    {
+        this.webSocket = webSocket;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        log.debug("Closing web socket output stream: {} frames/{} bytes sent", framesSent, bytesSent);
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+        int queueSize;
+        while ((queueSize = webSocket.outQueue.size()) > 0)
+        {
+            log.debug("Flushing web socket output stream: {} frames left", queueSize);
+            sleep(10L);
+        }
+
+        super.flush();
+    }
+
+    @Override
+    public void write(final int b)
+    {
+        this.write(new byte[]
+            {
+                (byte) b
+            });
+    }
+
+    @Override
+    public void write(final byte[] bytes)
+    {
+        this.write(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public void write(final byte[] b, final int off, final int len)
+    {
+        while (webSocket.outQueue.size() > 50)
+        {
+            sleep(10L);
+        }
+
+        webSocket.send(ByteBuffer.wrap(b, off, len));
+
+        framesSent++;
+        bytesSent += len;
+
+        log.trace("Sent binary message: frame #{} with {} bytes", framesSent, len);
+    }
+
+    private void sleep(final long millis)
+    {
+        try
+        {
+            Thread.sleep(10);
+        }
+        catch (final InterruptedException ex)
+        {
+        }
+    }
+}


### PR DESCRIPTION
* introduced some waiting time if the outbound message queue has >50 messages waiting to give ping/pong packets the chance to slip in
* ensure any queued message has been sent before closing the connection
* disabled the ping interval as pings are controlled by the XLT relay
* added much more debug output (to be activated with log level TRACE)
* moved WebSocketOutputStream into an own file
* unified code shared between XTC and XLT (WebSocketOutputStream and StreamingWebSocket)